### PR TITLE
Modernize POMM utilities

### DIFF
--- a/ryan-scripts/TUFLOW-python/POMM-max-aep-dur.py
+++ b/ryan-scripts/TUFLOW-python/POMM-max-aep-dur.py
@@ -6,11 +6,7 @@ from ryan_library.scripts.pomm_max_items import run_peak_report_modern
 
 
 def main() -> None:
-    """Wrapper script for peak reporting.
-
-    Mirrors :mod:`POMM_combine` so it can be called directly from QGIS or a
-    command prompt.
-    """
+    """Wrapper script for peak reporting."""
 
     try:
         script_directory: Path = Path(__file__).resolve().parent

--- a/ryan-scripts/TUFLOW-python/POMM-max-aep-dur.py
+++ b/ryan-scripts/TUFLOW-python/POMM-max-aep-dur.py
@@ -2,21 +2,28 @@
 
 from pathlib import Path
 import os
-from ryan_library.scripts.pomm_max_items import run_peak_report
+from ryan_library.scripts.pomm_max_items import run_peak_report_modern
 
 
-def main():
+def main() -> None:
+    """Wrapper script for peak reporting.
+
+    Mirrors :mod:`POMM_combine` so it can be called directly from QGIS or a
+    command prompt.
     """
-    Wrapper script to generate peak reports based on 'AEP' and 'Duration'.
-    """
 
-    # Determine the script directory and change the working directory to it
-    script_directory = Path(__file__).resolve().parent
-    os.chdir(script_directory)
+    try:
+        script_directory: Path = Path(__file__).resolve().parent
+        os.chdir(script_directory)
+    except Exception as e:  # pragma: no cover - manual execution
+        print(f"Failed to change working directory: {e}")
+        os.system("PAUSE")
+        raise
 
-    # Run the peak report generation
-    run_peak_report()
+    print(f"Current Working Directory: {Path.cwd()}")
+    run_peak_report_modern(script_directory=script_directory)
 
 
 if __name__ == "__main__":
     main()
+    os.system("PAUSE")

--- a/ryan-scripts/TUFLOW-python/POMM_combine.py
+++ b/ryan-scripts/TUFLOW-python/POMM_combine.py
@@ -3,10 +3,7 @@
 import os
 from pathlib import Path
 
-from ryan_library.scripts.pomm_combine import (
-    combine_processors_from_paths,
-    export_results,
-)
+from ryan_library.scripts.pomm_combine import main_processing
 
 console_log_level = "INFO"  # "DEBUG" "INFO"
 
@@ -33,12 +30,11 @@ def main() -> None:
         exit(1)
 
     print(f"Current Working Directory: {Path.cwd()}")
-    processors = combine_processors_from_paths(
+    main_processing(
         paths_to_process=[script_directory],
         include_data_types=["POMM"],
         console_log_level=console_log_level,
     )
-    export_results(processors)
 
 
 if __name__ == "__main__":

--- a/ryan-scripts/TUFLOW-python/POMM_combine.py
+++ b/ryan-scripts/TUFLOW-python/POMM_combine.py
@@ -1,8 +1,12 @@
 # POMM_combine.py
 
-from ryan_library.scripts.pomm_combine import main_processing
 import os
 from pathlib import Path
+
+from ryan_library.scripts.pomm_combine import (
+    combine_processors_from_paths,
+    export_results,
+)
 
 console_log_level = "INFO"  # "DEBUG" "INFO"
 
@@ -29,13 +33,12 @@ def main() -> None:
         exit(1)
 
     print(f"Current Working Directory: {Path.cwd()}")
-    main_processing(
+    processors = combine_processors_from_paths(
         paths_to_process=[script_directory],
-        include_data_types=[
-            "POMM",
-        ],
+        include_data_types=["POMM"],
         console_log_level=console_log_level,
     )
+    export_results(processors)
 
 
 if __name__ == "__main__":

--- a/ryan_library/processors/tuflow/processor_collection.py
+++ b/ryan_library/processors/tuflow/processor_collection.py
@@ -3,7 +3,11 @@
 from loguru import logger
 import pandas as pd
 from pandas import DataFrame
-from ryan_library.functions.dataframe_helpers import reorder_columns, reorder_long_columns, reset_categorical_ordering
+from ryan_library.functions.dataframe_helpers import (
+    reorder_columns,
+    reorder_long_columns,
+    reset_categorical_ordering,
+)
 from ryan_library.processors.tuflow.base_processor import BaseProcessor
 
 
@@ -26,7 +30,9 @@ class ProcessorCollection:
             self.processors.append(processor)
             logger.debug(f"Added processor: {processor.file_name}")
         else:
-            logger.warning(f"Attempted to add unprocessed processor: {processor.file_name}")
+            logger.warning(
+                f"Attempted to add unprocessed processor: {processor.file_name}"
+            )
 
     def combine_1d_timeseries(self) -> pd.DataFrame:
         """Combine DataFrames where dataformat is 'Timeseries'.
@@ -55,7 +61,9 @@ class ProcessorCollection:
         columns_to_drop: list[str] = ["file", "rel_path", "path", "directory_path"]
 
         # Check for existing columns and drop them
-        existing_columns_to_drop: list[str] = [col for col in columns_to_drop if col in combined_df.columns]
+        existing_columns_to_drop: list[str] = [
+            col for col in columns_to_drop if col in combined_df.columns
+        ]
         if existing_columns_to_drop:
             combined_df.drop(columns=existing_columns_to_drop, inplace=True)
             logger.debug(f"Dropped columns {existing_columns_to_drop} from DataFrame.")
@@ -64,7 +72,9 @@ class ProcessorCollection:
         # Reset categorical ordering
         # Group by 'internalName', 'Chan ID', and 'Time'
         group_keys: list[str] = ["internalName", "Chan ID", "Time"]
-        missing_keys: list[str] = [key for key in group_keys if key not in combined_df.columns]
+        missing_keys: list[str] = [
+            key for key in group_keys if key not in combined_df.columns
+        ]
         if missing_keys:
             logger.error(f"Missing group keys {missing_keys} in Timeseries data.")
             return pd.DataFrame()
@@ -72,7 +82,9 @@ class ProcessorCollection:
         combined_df = reorder_long_columns(df=combined_df)
 
         grouped_df: DataFrame = combined_df.groupby(group_keys).agg("max").reset_index()
-        logger.debug(f"Grouped {len(timeseries_processors)} Timeseries DataFrame with {len(grouped_df)} rows.")
+        logger.debug(
+            f"Grouped {len(timeseries_processors)} Timeseries DataFrame with {len(grouped_df)} rows."
+        )
 
         return grouped_df
 
@@ -95,14 +107,18 @@ class ProcessorCollection:
             return pd.DataFrame()
 
         # Concatenate DataFrames
-        combined_df: DataFrame = pd.concat([p.df for p in maximums_processors if not p.df.empty], ignore_index=True)
+        combined_df: DataFrame = pd.concat(
+            [p.df for p in maximums_processors if not p.df.empty], ignore_index=True
+        )
         logger.debug(f"Combined Maximums/ccA DataFrame with {len(combined_df)} rows.")
 
         # Columns to drop
         columns_to_drop: list[str] = ["file", "rel_path", "path", "Time"]
 
         # Check for existing columns and drop them
-        existing_columns_to_drop: list[str] = [col for col in columns_to_drop if col in combined_df.columns]
+        existing_columns_to_drop: list[str] = [
+            col for col in columns_to_drop if col in combined_df.columns
+        ]
         if existing_columns_to_drop:
             combined_df.drop(columns=existing_columns_to_drop, inplace=True)
             logger.debug(f"Dropped columns {existing_columns_to_drop} from DataFrame.")
@@ -113,12 +129,16 @@ class ProcessorCollection:
 
         # Group by 'internalName' and 'Chan ID'
         group_keys: list[str] = ["internalName", "Chan ID"]
-        missing_keys: list[str] = [key for key in group_keys if key not in combined_df.columns]
+        missing_keys: list[str] = [
+            key for key in group_keys if key not in combined_df.columns
+        ]
         if missing_keys:
             logger.error(f"Missing group keys {missing_keys} in Maximums/ccA data.")
             return pd.DataFrame()
 
-        grouped_df: DataFrame = combined_df.groupby(by=group_keys, observed=False).agg("max").reset_index()
+        grouped_df: DataFrame = (
+            combined_df.groupby(by=group_keys, observed=False).agg("max").reset_index()
+        )
         p1_col: list[str] = [
             "trim_runcode",
             "aep_text",
@@ -153,7 +173,9 @@ class ProcessorCollection:
             prefix_order=["R"],
             second_priority_columns=p2_col,
         )
-        logger.debug(f"Grouped {len(maximums_processors)} Maximums/ccA DataFrame with {len(grouped_df)} rows.")
+        logger.debug(
+            f"Grouped {len(maximums_processors)} Maximums/ccA DataFrame with {len(grouped_df)} rows."
+        )
         logger.debug("line157")
         return grouped_df
 
@@ -165,7 +187,9 @@ class ProcessorCollection:
         logger.debug("Combining raw data without grouping.")
 
         # Concatenate all DataFrames
-        combined_df: DataFrame = pd.concat([p.df for p in self.processors if not p.df.empty], ignore_index=True)
+        combined_df: DataFrame = pd.concat(
+            [p.df for p in self.processors if not p.df.empty], ignore_index=True
+        )
         logger.debug(f"Combined Raw DataFrame with {len(combined_df)} rows.")
 
         combined_df = reorder_long_columns(df=combined_df)
@@ -184,15 +208,21 @@ class ProcessorCollection:
         logger.debug("Combining POMM data.")
 
         # Filter processors with dataformat 'POMM'
-        pomm_processors: list[BaseProcessor] = [p for p in self.processors if p.dataformat.lower() == "pomm"]
+        pomm_processors: list[BaseProcessor] = [
+            p for p in self.processors if p.dataformat.lower() == "pomm"
+        ]
 
         if not pomm_processors:
             logger.warning("No processors with dataformat 'POMM' found.")
             return pd.DataFrame()
 
         # Concatenate DataFrames
-        combined_df: DataFrame = pd.concat([p.df for p in pomm_processors if not p.df.empty], ignore_index=True)
-        logger.debug(f"Combined {len(pomm_processors)}  POMM DataFrame with {len(combined_df)} rows.")
+        combined_df: DataFrame = pd.concat(
+            [p.df for p in pomm_processors if not p.df.empty], ignore_index=True
+        )
+        logger.debug(
+            f"Combined {len(pomm_processors)}  POMM DataFrame with {len(combined_df)} rows."
+        )
 
         combined_df = reorder_long_columns(df=combined_df)
 
@@ -210,15 +240,21 @@ class ProcessorCollection:
         logger.debug("Combining PO data.")
 
         # Filter processors with dataformat 'PO'
-        po_processors: list[BaseProcessor] = [p for p in self.processors if p.dataformat.lower() == "po"]
+        po_processors: list[BaseProcessor] = [
+            p for p in self.processors if p.dataformat.lower() == "po"
+        ]
 
         if not po_processors:
             logger.warning("No processors with dataformat 'PO' found.")
             return pd.DataFrame()
 
         # Concatenate DataFrames
-        combined_df = pd.concat([p.df for p in po_processors if not p.df.empty], ignore_index=True)
-        logger.debug(f"Combined {len(po_processors)} PO DataFrame with {len(combined_df)} rows.")
+        combined_df = pd.concat(
+            [p.df for p in po_processors if not p.df.empty], ignore_index=True
+        )
+        logger.debug(
+            f"Combined {len(po_processors)} PO DataFrame with {len(combined_df)} rows."
+        )
 
         combined_df: DataFrame = reorder_long_columns(df=combined_df)
 
@@ -227,7 +263,9 @@ class ProcessorCollection:
 
         return combined_df
 
-    def get_processors_by_data_type(self, data_types: list[str] | str) -> "ProcessorCollection":
+    def get_processors_by_data_type(
+        self, data_types: list[str] | str
+    ) -> "ProcessorCollection":
         """Retrieve processors matching a specific data_type or list of data_types.
 
         Args:
@@ -271,8 +309,8 @@ class ProcessorCollection:
 
         for proc in self.processors:
             # use the raw run code as the internalName
-            run_code = proc.name_parser.raw_run_code
-            key = (run_code, proc.data_type)
+            run_code: str = proc.name_parser.raw_run_code
+            key: tuple[str, str] = (run_code, proc.data_type)
             groups[key].append(proc)
 
         # filter to only “duplicates”
@@ -282,7 +320,8 @@ class ProcessorCollection:
             for (run_code, dtype), procs in duplicates.items():
                 files = ", ".join(p.file_name for p in procs)
                 logger.warning(
-                    f"Potential duplicate group: run_code='{run_code}', " f"data_type='{dtype}' found in files: {files}"
+                    f"Potential duplicate group: run_code='{run_code}', "
+                    f"data_type='{dtype}' found in files: {files}"
                 )
         else:
             logger.debug("No duplicate processors found by run_code & data_type.")

--- a/ryan_library/scripts/pomm_combine.py
+++ b/ryan_library/scripts/pomm_combine.py
@@ -1,56 +1,34 @@
-# ryan_library/scripts/pomm_combine.py
+"""Modern POMM combination utilities."""
 
-import os
-from multiprocessing import Pool
 from pathlib import Path
 import pandas as pd
 from loguru import logger
-import logging
-import multiprocessing
-from glob import iglob
-from datetime import datetime
 
-from ryan_library.functions.file_utils import (
-    find_files_parallel,
-    is_non_zero_file,
-    ensure_output_directory,
+from ryan_library.scripts.pomm_utils import (
+    collect_files,
+    process_files_in_parallel,
+    combine_processors_from_paths,
+    combine_df_from_paths,
 )
-from ryan_library.functions.misc_functions import calculate_pool_size, ExcelExporter
-from ryan_library.functions.data_processing import (
-    safe_apply,
-    check_string_TP,
-    check_string_duration,
-    check_string_aep,
-)
-from ryan_library.processors.tuflow.base_processor import BaseProcessor
 from ryan_library.processors.tuflow.processor_collection import ProcessorCollection
+from ryan_library.functions.file_utils import ensure_output_directory
+from ryan_library.functions.misc_functions import ExcelExporter
 from ryan_library.classes.suffixes_and_dtypes import SuffixesConfig
-from ryan_library.functions.loguru_helpers import (
-    setup_logger,
-    log_exception,
-    worker_initializer,
-)
-from ryan_library.functions.logging_helpers import setup_logging
+from ryan_library.functions.loguru_helpers import setup_logger
 
 
 def main_processing(
     paths_to_process: list[Path],
-    include_data_types: list[str] = ["POMM"],
+    include_data_types: list[str] | None = None,
     console_log_level: str = "INFO",
 ) -> None:
-    """Generate merged culvert data by processing various TUFLOW CSV and CCA files.
+    """Generate merged culvert data and export the results."""
 
-    Args:
-        paths_to_process (list[Path]): List of directory paths to search for files.
-        include_data_types (list[str] | None): List of data types to include. If None, include all.
-        console_log_level (str): Logging level for the console."""
+    if include_data_types is None:
+        include_data_types = ["POMM"]
 
     with setup_logger(console_log_level=console_log_level) as log_queue:
-        logger.info("Starting culvert results files processing...")
-        logger.info(f"Current working directory: {os.getcwd()}")
-
-        # Step 1: Collect and validate files
-        csv_file_list: list[Path] = collect_files(
+        csv_file_list = collect_files(
             paths_to_process=paths_to_process,
             include_data_types=include_data_types,
             suffixes_config=SuffixesConfig.get_instance(),
@@ -59,344 +37,35 @@ def main_processing(
             logger.info("No valid files found to process.")
             return
 
-        logger.debug(f"Files to process: {csv_file_list}")
-        logger.info(f"Total files to process: {len(csv_file_list)}")
+        results_set = process_files_in_parallel(file_list=csv_file_list, log_queue=log_queue)
 
-        # Step 2: Process files in parallel
-
-        results_set: ProcessorCollection = process_files_in_parallel(
-            file_list=csv_file_list,
-            log_queue=log_queue,
-        )
-
-        # Step 3: Combine and export results based on scenarios
-        logger.info("Now exporting results...")
-        export_results(results=results_set)
-
-        logger.info("End of culvert results combination processing")
-
-
-def collect_files(
-    paths_to_process: list[Path],
-    include_data_types: list[str],
-    suffixes_config: SuffixesConfig,
-) -> list[Path]:
-    """Collect and filter files based on specified data types.
-
-    Args:
-        paths_to_process (list[Path]): Directories to search.
-        include_data_types (list[str] ): List of data types to include.
-        suffixes_config (SuffixesConfig ): Suffixes configuration instance.
-
-    Returns:
-        list[Path]: List of valid file paths."""
-
-    csv_file_list: list[Path] = []
-    suffixes: list[str] = []
-
-    # Determine which suffixes to include based on data types
-    # Invert suffixes config
-    data_type_to_suffix: dict[str, list[str]] = suffixes_config.invert_suffix_to_type()
-
-    if include_data_types and len(include_data_types) > 0:
-        for data_type in include_data_types:
-            dt_suffixes: list[str] | None = data_type_to_suffix.get(data_type)
-            if not dt_suffixes:
-                logger.error(
-                    f"No suffixes found for data type '{data_type}'. Skipping."
-                )
-                continue
-            suffixes.extend([s for s in dt_suffixes])  # Preserve capitalization
-
-    if not suffixes:
-        logger.error("No suffixes found for the specified data types.")
-        return csv_file_list
-
-    # Prepend '*' for wildcard searching
-    patterns: list[str] = [f"*{suffix}" for suffix in suffixes]
-
-    root_dirs: list[Path] = [p for p in paths_to_process if p.is_dir()]
-    invalid_dirs: set[Path] = set(paths_to_process) - set(root_dirs)
-    for invalid_dir in invalid_dirs:
-        logger.warning(f"Path {invalid_dir} is not a directory. Skipping.")
-
-    matched_files: list[Path] = find_files_parallel(
-        root_dirs=root_dirs, patterns=patterns
-    )
-    csv_file_list.extend(matched_files)
-
-    # Filter for non-zero files
-    csv_file_list = [f for f in csv_file_list if is_non_zero_file(f)]
-    # logger.debug(f"Collected files: {csv_file_list}")
-
-    return csv_file_list
-
-
-def process_files_in_parallel(file_list: list[Path], log_queue) -> ProcessorCollection:
-    """Process files using multiprocessing.
-
-    Args:
-        file_list (list[Path]): Files to process.
-        log_queue (Queue): Logging queue.
-
-    Returns:
-        ProcessorCollection: Collection of successfully processed processors."""
-    pool_size: int = calculate_pool_size(num_files=len(file_list))
-    logger.info(f"Initializing multiprocessing pool with {pool_size} processes.")
-
-    results_set = ProcessorCollection()
-    # Initialize the Pool with the worker initializer and pass the log_queue via initargs
-
-    with Pool(
-        processes=pool_size,
-        initializer=worker_initializer,
-        initargs=(log_queue,),
-    ) as pool:
-        results: list[BaseProcessor] = pool.map(func=process_file, iterable=file_list)
-
-    for result in results:
-        if result is not None and result.processed:
-            results_set.add_processor(processor=result)
-
-    return results_set
-
-
-def process_file(file_path: Path) -> BaseProcessor:
-    """Process a single file by delegating to BaseProcessor.
-
-    Args:
-        file_path (Path): Path to the file to process.
-
-    Returns:
-        BaseProcessor: The processed BaseProcessor instance.
-
-    Raises:
-        Exception: If processing fails."""
-    try:
-        # BaseProcessor.from_file determines and instantiates the correct processor
-        processor: BaseProcessor = BaseProcessor.from_file(file_path=file_path)
-        processor.process()
-
-        if processor.validate_data():
-            logger.info(f"Successfully processed file: {file_path}")
-        else:
-            logger.warning(f"Validation failed for file: {file_path}")
-        return processor
-    except Exception as e:
-        logger.exception(f"Failed to process file {file_path}: {e}")
-        raise
+    export_results(results_set)
 
 
 def export_results(results: ProcessorCollection) -> None:
-    """Export combined DataFrames
-    Args:
-        results (ProcessorCollection): Collection of processed processors."""
+    """Export combined DataFrames to Excel."""
     if not results.processors:
         logger.warning("No results to export.")
         return
 
     exporter = ExcelExporter()
+    combined_df: pd.DataFrame = results.pomm_combine()
+    if combined_df.empty:
+        logger.warning("No combined data found. Skipping export.")
+        return
 
-    # Scenario 1: combine_1d_maximums
-    scenario1 = "combined_POMM"
-    file_name_prefix1 = "combined_POMM"
-    sheet_name1 = "combined_POMM"
-    output_path1: Path = Path.cwd()
-    # Path("exports/maximums")  # Optional: Specify your desired path
-
-    combined_df1: pd.DataFrame = results.pomm_combine()
-
-    if combined_df1.empty:
-        logger.warning(f"No data found for scenario '{scenario1}'. Skipping export.")
-    else:
-        # Ensure the output directory exists
-        ensure_output_directory(output_dir=output_path1)
-
-        # Perform the export for combine_1d_maximums
-        exporter.save_to_excel(
-            data_frame=combined_df1,
-            file_name_prefix=file_name_prefix1,
-            sheet_name=sheet_name1,
-            output_directory=output_path1,  # Pass the optional path
-        )
-        logger.info(f"Exported data for scenario '{scenario1}' successfully.")
+    ensure_output_directory(output_dir=Path.cwd())
+    exporter.save_to_excel(
+        data_frame=combined_df,
+        file_name_prefix="combined_POMM",
+        sheet_name="combined_POMM",
+        output_directory=Path.cwd(),
+    )
 
 
-# ---------------------------------------------------------------------------
-# Legacy functions preserved for backward compatibility
-# ---------------------------------------------------------------------------
-
-
-def process_pomm_file(file_path: str) -> pd.DataFrame:
-    """Process a single POMM CSV file and transform it into a standardized DataFrame.
-
-    This includes renaming columns, type casting, extracting run code parts, and
-    calculating additional metrics.
-
-    Args:
-        file_path (str): Path to the POMM CSV file.
-
-    Returns:
-        pd.DataFrame: Transformed DataFrame with necessary calculations.
-                      Returns an empty DataFrame if an error occurs.
-    """
-
-    logging.info(f"Processing file: {file_path}")
-
-    try:
-        original_df = pd.read_csv(filepath_or_buffer=file_path, header=None)
-
-        run_code = original_df.iat[0, 0]
-
-        transposed_df = original_df.drop(columns=0).T
-
-        transposed_df.columns = pd.Index(transposed_df.iloc[0], dtype=str)
-        transposed_df = transposed_df.drop(index=transposed_df.index[0])
-
-        column_mappings = {
-            "Type": ("Location", "string"),
-            "Location": ("Time", "string"),
-            "Max": ("Maximum (Extracted from Time Series)", "float"),
-            "Tmax": ("Time of Maximum", "float"),
-            "Min": ("Minimum (Extracted From Time Series)", "float"),
-            "Tmin": ("Time of Minimum", "float"),
-        }
-
-        for new_col, (old_col, dtype) in column_mappings.items():
-            if old_col in transposed_df.columns:
-                transposed_df.rename(columns={old_col: new_col}, inplace=True)
-                transposed_df[new_col] = transposed_df[new_col].astype(dtype)
-
-        run_code_parts: list[str] = run_code.replace("+", "_").split("_")
-        for index, part in enumerate(run_code_parts, start=1):
-            transposed_df.insert(index, f"R{index:02}", str(part))
-
-        transposed_df["AbsMax"] = transposed_df[["Max", "Min"]].abs().max(axis=1)
-
-        transposed_df["SignedAbsMax"] = transposed_df.apply(
-            lambda row: row["Max"] if abs(row["Max"]) >= abs(row["Min"]) else row["Min"],
-            axis=1,
-        )
-
-        transposed_df["TP"] = safe_apply(check_string_TP, run_code)
-        transposed_df["Duration"] = safe_apply(check_string_duration, run_code)
-        transposed_df["AEP"] = safe_apply(check_string_aep, run_code)
-        transposed_df["RunCode"] = run_code
-
-        transposed_df["TrimmedRunCode"] = transposed_df.apply(
-            lambda row: clean_runcode(
-                run_code=row["RunCode"],
-                aep=row["AEP"] + "p" if row["AEP"] is not None else None,
-                duration=row["Duration"] + "m" if row["Duration"] is not None else None,
-                tp="TP" + row["TP"] if row["TP"] is not None else None,
-            ),
-            axis=1,
-        )
-
-        return transposed_df
-
-    except Exception as e:  # pragma: no cover - safety net
-        logging.error(f"Error processing file {file_path}: {e}", exc_info=True)
-        return pd.DataFrame()
-
-
-def clean_runcode(run_code: str, aep: str | None, duration: str | None, tp: str | None) -> str:
-    """Clean the RunCode by removing the extracted AEP, Duration, and TP values."""
-
-    if not isinstance(run_code, str):
-        logging.error(f"RunCode must be a string. Received type: {type(run_code)}")
-        return ""
-
-    standardized_runcode = run_code.replace("+", "_")
-    parts = standardized_runcode.split("_")
-
-    parts_to_remove = set()
-    if aep:
-        parts_to_remove.add(aep)
-    if duration:
-        parts_to_remove.add(duration)
-    if tp:
-        parts_to_remove.add(tp)
-
-    filtered_parts = [part for part in parts if part not in parts_to_remove and part.strip() != ""]
-
-    cleaned_runcode = "_".join(filtered_parts)
-    logging.debug(f"Original RunCode: {run_code}, Cleaned RunCode: {cleaned_runcode}")
-
-    return cleaned_runcode
-
-
-def aggregate_pomm_data(pomm_data: list[pd.DataFrame]) -> pd.DataFrame:
-    """Aggregate a list of DataFrames into a single DataFrame."""
-
-    valid_data_frames = [df for df in pomm_data if not df.empty]
-    aggregated_df = pd.concat(valid_data_frames, ignore_index=True)
-    return aggregated_df
-
-
-def save_to_excel(aep_dur_max: pd.DataFrame, aep_max: pd.DataFrame, output_path: Path):
-    """Save the provided DataFrames to an Excel file with separate sheets."""
-
-    try:
-        logging.info(f"Output path: {output_path}")
-        with pd.ExcelWriter(output_path) as writer:
-            aep_dur_max.to_excel(writer, sheet_name="aep-dur-max", index=False, merge_cells=False)
-            aep_max.to_excel(writer, sheet_name="aep-max", index=False, merge_cells=False)
-        logging.info(f"Peak data exported to {output_path}")
-    except Exception as e:  # pragma: no cover - safety net
-        logging.error(f"Failed to save peak data to Excel: {e}")
-
-
-def save_aggregated_data(aggregated_df: pd.DataFrame, output_path: Path):
-    """Save the aggregated DataFrame to an Excel file."""
-
-    try:
-        aggregated_df.to_excel(output_path, index=False)
-        logging.info(f"Aggregated data exported to {output_path}")
-    except Exception as e:  # pragma: no cover - safety net
-        logging.error(f"Failed to save aggregated data to Excel: {e}")
-
-
-def process_all_files(pomm_files: list[str]) -> pd.DataFrame:
-    """Process all POMM files and aggregate the data."""
-
-    if not pomm_files:
-        logging.warning("No POMM CSV files found. Exiting.")
-        return pd.DataFrame()
-
-    pool_size = calculate_pool_size(len(pomm_files))
-
-    with multiprocessing.Pool(pool_size) as pool:
-        pomm_data = pool.map(process_pomm_file, pomm_files)
-
-    aggregated_df = aggregate_pomm_data(pomm_data)
-    logging.info("Aggregated POMM DataFrame head:")
-    logging.info(f"\n{aggregated_df.head()}")
-    return aggregated_df
-
-
-def legacy_main_processing() -> None:
-    """Legacy main processing for backward compatibility."""
-
-    start_time = datetime.now()
-    setup_logging()
-
-    script_directory = Path.cwd().resolve()
-
-    pomm_files = [str(f) for f in iglob("**/*POMM.csv", recursive=True) if Path(f).is_file()]
-    logging.info(f"Number of POMM files found: {len(pomm_files)}")
-
-    aggregated_df = process_all_files(pomm_files)
-
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M")
-    output_filename_aggregated = f"{timestamp}_POMM.xlsx"
-    output_path_aggregated = script_directory / output_filename_aggregated
-    save_aggregated_data(aggregated_df, output_path_aggregated)
-
-    end_time = datetime.now()
-    runtime = end_time - start_time
-    logging.info(f"Total run time: {runtime}")
-
-
-if __name__ == "__main__":  # pragma: no cover - manual execution
-    legacy_main_processing()
+__all__ = [
+    "main_processing",
+    "combine_processors_from_paths",
+    "combine_df_from_paths",
+    "export_results",
+]

--- a/ryan_library/scripts/pomm_combine.py
+++ b/ryan_library/scripts/pomm_combine.py
@@ -7,8 +7,6 @@ from loguru import logger
 from ryan_library.scripts.pomm_utils import (
     collect_files,
     process_files_in_parallel,
-    combine_processors_from_paths,
-    combine_df_from_paths,
 )
 from ryan_library.processors.tuflow.processor_collection import ProcessorCollection
 from ryan_library.functions.file_utils import ensure_output_directory
@@ -28,7 +26,7 @@ def main_processing(
         include_data_types = ["POMM"]
 
     with setup_logger(console_log_level=console_log_level) as log_queue:
-        csv_file_list = collect_files(
+        csv_file_list: list[Path] = collect_files(
             paths_to_process=paths_to_process,
             include_data_types=include_data_types,
             suffixes_config=SuffixesConfig.get_instance(),
@@ -37,9 +35,12 @@ def main_processing(
             logger.info("No valid files found to process.")
             return
 
-        results_set = process_files_in_parallel(file_list=csv_file_list, log_queue=log_queue)
+        results_set: ProcessorCollection = process_files_in_parallel(
+            file_list=csv_file_list, log_queue=log_queue
+        )
 
-    export_results(results_set)
+    export_results(results=results_set)
+    logger.info("End of POMM results combination processing")
 
 
 def export_results(results: ProcessorCollection) -> None:
@@ -61,11 +62,3 @@ def export_results(results: ProcessorCollection) -> None:
         sheet_name="combined_POMM",
         output_directory=Path.cwd(),
     )
-
-
-__all__ = [
-    "main_processing",
-    "combine_processors_from_paths",
-    "combine_df_from_paths",
-    "export_results",
-]

--- a/ryan_library/scripts/pomm_max_items.py
+++ b/ryan_library/scripts/pomm_max_items.py
@@ -5,67 +5,19 @@ from pathlib import Path
 from datetime import datetime
 import pandas as pd
 
-from ryan_library.scripts.pomm_combine import (
-    process_pomm_file,
-    aggregate_pomm_data,
-    save_to_excel,
+from ryan_library.scripts.pomm_utils import (
+    aggregated_from_paths,
+    save_peak_report,
 )
-from ryan_library.functions.misc_functions import calculate_pool_size
-import multiprocessing
 from ryan_library.functions.logging_helpers import setup_logging
 
 
-def find_and_save_peaks(
-    aggregated_df: pd.DataFrame,
-    script_directory: Path,
-    timestamp: str,
-    suffix: str = "_peaks.xlsx",
-) -> None:
-    """
-    Find peak records and save them to an Excel file.
-
-    Args:
-        aggregated_df (pd.DataFrame): The aggregated DataFrame.
-        script_directory (Path): Directory where the Excel file will be saved.
-        timestamp (str): Timestamp string for the filename.
-        suffix (str): Suffix for the filename. Default is '_peaks.xlsx'.
-    """
-    aep_dur_max = find_aep_dur_max(aggregated_df)
-    aep_max = find_aep_max(aggregated_df)
-    output_filename_peaks = f"{timestamp}{suffix}"
-    output_path_peaks = script_directory / output_filename_peaks
-    save_to_excel(aep_dur_max, aep_max, output_path_peaks)
 
 
 def generate_peak_report(pomm_files: list[str], output_path: Path) -> None:
-    """
-    Generate peak reports by processing POMM CSV files, finding peak records,
-    and saving them into an Excel file with separate sheets.
-
-    Args:
-        pomm_files (list[str]): List of POMM CSV file paths.
-        output_path (Path): Path where the Excel file will be saved.
-    """
-    if not pomm_files:
-        logging.warning("No POMM CSV files found. Exiting.")
-        return
-
-    # Calculate the number of worker processes
-    pool_size = calculate_pool_size(len(pomm_files))
-
-    # Create a multiprocessing pool and process files
-    with multiprocessing.Pool(pool_size) as pool:
-        pomm_data = pool.map(process_pomm_file, pomm_files)
-
-    # Aggregate all processed DataFrames
-    aggregated_df = aggregate_pomm_data(pomm_data)
-    logging.info("Aggregated POMM DataFrame head:")
-    logging.info(f"\n{aggregated_df.head()}")
-
-    # Find and save peak records
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M")
-    find_and_save_peaks(
-        aggregated_df=aggregated_df, script_directory=output_path, timestamp=timestamp
+    """Deprecated entry point kept for API compatibility."""
+    raise RuntimeError(
+        "generate_peak_report has been removed. Use 'run_peak_report_modern' instead."
     )
 
 
@@ -76,57 +28,31 @@ def run_peak_report(script_directory: Path | None = None) -> None:
     Args:
         script_directory (Path): Directory to search for POMM CSV files and save reports.
     """
-    # Set up logging
+    raise RuntimeError(
+        "run_peak_report has been removed. Use the \n"
+        "'POMM-max-aep-dur.py' wrapper in ryan-scripts/TUFLOW-python instead."
+    )
+
+
+def run_peak_report_modern(script_directory: Path | None = None) -> None:
+    """Locate and process POMM files and export their peak values."""
+
     setup_logging()
     logging.info(f"Current Working Directory: {Path.cwd()}")
     if script_directory is None:
         script_directory = Path.cwd()
 
-    # Find all POMM CSV files recursively
-    pomm_files: list[str] = [
-        str(f) for f in script_directory.rglob("**/*POMM.csv") if f.is_file()
-    ]
-    logging.info(f"Number of POMM files found: {len(pomm_files)}")
+    aggregated_df: pd.DataFrame = aggregated_from_paths([script_directory])
 
-    if not pomm_files:
+    if aggregated_df.empty:
         logging.warning("No POMM CSV files found. Exiting.")
         return
 
-    # Generate a timestamped filename for the output Excel file with peaks
     timestamp = datetime.now().strftime("%Y%m%d-%H%M")
-    output_path_peaks = script_directory
-
-    # Generate the peak report
-    generate_peak_report(pomm_files, output_path_peaks)
-
-
-def find_aep_dur_max(aggregated_df: pd.DataFrame) -> pd.DataFrame:
-    try:
-        aep_dur_max = aggregated_df.loc[
-            aggregated_df.groupby(
-                ["AEP", "Duration", "Location", "Type", "TrimmedRunCode"]
-            )["AbsMax"].idxmax()
-        ].reset_index(drop=True)
-        logging.info(
-            "Created 'aep_dur_max' DataFrame with peak records for each AEP-Duration-Location-Type-RunCode group."
-        )
-    except KeyError as e:
-        logging.error(f"Missing expected columns for 'aep_dur_max' grouping: {e}")
-        aep_dur_max = pd.DataFrame()
-    return aep_dur_max
+    save_peak_report(
+        aggregated_df=aggregated_df,
+        script_directory=script_directory,
+        timestamp=timestamp,
+    )
 
 
-def find_aep_max(aep_dur_max: pd.DataFrame) -> pd.DataFrame:
-    try:
-        aep_max = aep_dur_max.loc[
-            aep_dur_max.groupby(["AEP", "Location", "Type", "TrimmedRunCode"])[
-                "AbsMax"
-            ].idxmax()
-        ].reset_index(drop=True)
-        logging.info(
-            "Created 'aep_max' DataFrame with peak records for each AEP group."
-        )
-    except KeyError as e:
-        logging.error(f"Missing expected columns for 'aep_max' grouping: {e}")
-        aep_max = pd.DataFrame()
-    return aep_max

--- a/ryan_library/scripts/pomm_max_items.py
+++ b/ryan_library/scripts/pomm_max_items.py
@@ -1,6 +1,6 @@
 # ryan_library/scripts/pomm_max_items.py
 
-import logging
+from loguru import logger
 from pathlib import Path
 from datetime import datetime
 import pandas as pd
@@ -12,8 +12,6 @@ from ryan_library.scripts.pomm_utils import (
 from ryan_library.functions.logging_helpers import setup_logging
 
 
-
-
 def generate_peak_report(pomm_files: list[str], output_path: Path) -> None:
     """Deprecated entry point kept for API compatibility."""
     raise RuntimeError(
@@ -22,12 +20,7 @@ def generate_peak_report(pomm_files: list[str], output_path: Path) -> None:
 
 
 def run_peak_report(script_directory: Path | None = None) -> None:
-    """
-    Run the peak report generation workflow.
-
-    Args:
-        script_directory (Path): Directory to search for POMM CSV files and save reports.
-    """
+    """Run the peak report generation workflow."""
     raise RuntimeError(
         "run_peak_report has been removed. Use the \n"
         "'POMM-max-aep-dur.py' wrapper in ryan-scripts/TUFLOW-python instead."
@@ -38,21 +31,19 @@ def run_peak_report_modern(script_directory: Path | None = None) -> None:
     """Locate and process POMM files and export their peak values."""
 
     setup_logging()
-    logging.info(f"Current Working Directory: {Path.cwd()}")
+    logger.info(msg=f"Current Working Directory: {Path.cwd()}")
     if script_directory is None:
         script_directory = Path.cwd()
 
     aggregated_df: pd.DataFrame = aggregated_from_paths([script_directory])
 
     if aggregated_df.empty:
-        logging.warning("No POMM CSV files found. Exiting.")
+        logger.warning(msg="No POMM CSV files found. Exiting.")
         return
 
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M")
+    timestamp: str = datetime.now().strftime(format="%Y%m%d-%H%M")
     save_peak_report(
         aggregated_df=aggregated_df,
         script_directory=script_directory,
         timestamp=timestamp,
     )
-
-

--- a/ryan_library/scripts/pomm_utils.py
+++ b/ryan_library/scripts/pomm_utils.py
@@ -1,11 +1,12 @@
+# ryan_library/scripts/pomm_combine.py
 """Utility helpers for processing POMM CSV files."""
 
 from pathlib import Path
 from multiprocessing import Pool
-from typing import Iterable
-
+from collections.abc import Iterable
 import pandas as pd
 from loguru import logger
+from pandas import DataFrame
 
 from ryan_library.functions.file_utils import (
     find_files_parallel,
@@ -18,23 +19,30 @@ from ryan_library.classes.suffixes_and_dtypes import SuffixesConfig
 from ryan_library.functions.loguru_helpers import setup_logger, worker_initializer
 
 
-# ---------------------------------------------------------------------------
-# File collection and processing helpers
-# ---------------------------------------------------------------------------
-
 def collect_files(
     paths_to_process: Iterable[Path],
     include_data_types: Iterable[str],
     suffixes_config: SuffixesConfig,
 ) -> list[Path]:
-    """Collect and filter files based on suffix configuration."""
+    """Collect and filter files based on specified data types.
+
+    Args:
+        paths_to_process (list[Path]): Directories to search.
+        include_data_types (list[str] ): List of data types to include.
+        suffixes_config (SuffixesConfig ): Suffixes configuration instance.
+
+    Returns:
+        list[Path]: List of valid file paths."""
+
     csv_file_list: list[Path] = []
     suffixes: list[str] = []
 
-    data_type_to_suffix = suffixes_config.invert_suffix_to_type()
+    # Determine which suffixes to include based on data types
+    # Invert suffixes config
+    data_type_to_suffix: dict[str, list[str]] = suffixes_config.invert_suffix_to_type()
 
     for data_type in include_data_types:
-        dt_suffixes = data_type_to_suffix.get(data_type)
+        dt_suffixes: list[str] | None = data_type_to_suffix.get(data_type)
         if not dt_suffixes:
             logger.error(f"No suffixes found for data type '{data_type}'. Skipping.")
             continue
@@ -44,14 +52,17 @@ def collect_files(
         logger.error("No suffixes found for the specified data types.")
         return csv_file_list
 
-    patterns = [f"*{suffix}" for suffix in suffixes]
+    # Prepend '*' for wildcard searching
+    patterns: list[str] = [f"*{suffix}" for suffix in suffixes]
 
-    root_dirs = [p for p in paths_to_process if p.is_dir()]
-    invalid_dirs = set(paths_to_process) - set(root_dirs)
+    root_dirs: list[Path] = [p for p in paths_to_process if p.is_dir()]
+    invalid_dirs: set[Path] = set(paths_to_process) - set(root_dirs)
     for invalid_dir in invalid_dirs:
         logger.warning(f"Path {invalid_dir} is not a directory. Skipping.")
 
-    matched_files = find_files_parallel(root_dirs=root_dirs, patterns=patterns)
+    matched_files: list[Path] = find_files_parallel(
+        root_dirs=root_dirs, patterns=patterns
+    )
     csv_file_list.extend(matched_files)
 
     csv_file_list = [f for f in csv_file_list if is_non_zero_file(f)]
@@ -59,24 +70,41 @@ def collect_files(
 
 
 def process_file(file_path: Path) -> BaseProcessor:
-    """Process a single file using the :class:`BaseProcessor` hierarchy."""
-    processor = BaseProcessor.from_file(file_path=file_path)
-    processor.process()
-    if processor.validate_data():
-        logger.info(f"Successfully processed file: {file_path}")
-    else:
-        logger.warning(f"Validation failed for file: {file_path}")
-    return processor
+    """Process a single file by delegating to BaseProcessor.
+
+    Args:
+        file_path (Path): Path to the file to process.
+
+    Returns:
+        BaseProcessor: The processed BaseProcessor instance.
+
+    Raises:
+        Exception: If processing fails."""
+    try:
+        # BaseProcessor.from_file determines and instantiates the correct processor
+        processor: BaseProcessor = BaseProcessor.from_file(file_path=file_path)
+        processor.process()
+
+        if processor.validate_data():
+            logger.info(f"Successfully processed file: {file_path}")
+        else:
+            logger.warning(f"Validation failed for file: {file_path}")
+        return processor
+    except Exception as e:
+        logger.exception(f"Failed to process file {file_path}: {e}")
+        raise
 
 
 def process_files_in_parallel(file_list: list[Path], log_queue) -> ProcessorCollection:
     """Process files using multiprocessing and return a collection."""
-    pool_size = calculate_pool_size(num_files=len(file_list))
+    pool_size: int = calculate_pool_size(num_files=len(file_list))
     logger.info(f"Initializing multiprocessing pool with {pool_size} processes.")
 
     results_set = ProcessorCollection()
-    with Pool(processes=pool_size, initializer=worker_initializer, initargs=(log_queue,)) as pool:
-        results = pool.map(func=process_file, iterable=file_list)
+    with Pool(
+        processes=pool_size, initializer=worker_initializer, initargs=(log_queue,)
+    ) as pool:
+        results: list[BaseProcessor] = pool.map(func=process_file, iterable=file_list)
 
     for result in results:
         if result is not None and result.processed:
@@ -95,7 +123,7 @@ def combine_processors_from_paths(
 
     with setup_logger(console_log_level=console_log_level) as log_queue:
         logger.info("Starting POMM processing for combine_processors_from_paths.")
-        csv_file_list = collect_files(
+        csv_file_list: list[Path] = collect_files(
             paths_to_process=paths_to_process,
             include_data_types=include_data_types,
             suffixes_config=SuffixesConfig.get_instance(),
@@ -104,7 +132,9 @@ def combine_processors_from_paths(
             logger.info("No valid files found to process.")
             return ProcessorCollection()
 
-        results_set = process_files_in_parallel(file_list=csv_file_list, log_queue=log_queue)
+        results_set: ProcessorCollection = process_files_in_parallel(
+            file_list=csv_file_list, log_queue=log_queue
+        )
 
     return results_set
 
@@ -115,7 +145,7 @@ def combine_df_from_paths(
     console_log_level: str = "INFO",
 ) -> pd.DataFrame:
     """Return an aggregated DataFrame for the given directories."""
-    results_set = combine_processors_from_paths(
+    results_set: ProcessorCollection = combine_processors_from_paths(
         paths_to_process=paths_to_process,
         include_data_types=include_data_types,
         console_log_level=console_log_level,
@@ -127,10 +157,6 @@ def combine_df_from_paths(
     return results_set.pomm_combine()
 
 
-# ---------------------------------------------------------------------------
-# Peak report helpers
-# ---------------------------------------------------------------------------
-
 def aggregated_from_paths(paths: list[Path]) -> pd.DataFrame:
     """Process directories and return a combined POMM DataFrame."""
     return combine_df_from_paths(paths_to_process=paths)
@@ -138,26 +164,57 @@ def aggregated_from_paths(paths: list[Path]) -> pd.DataFrame:
 
 def find_aep_dur_max(aggregated_df: pd.DataFrame) -> pd.DataFrame:
     """Return peak rows for each AEP/Duration/Location/Type/RunCode group."""
-    return aggregated_df.loc[
-        aggregated_df.groupby(
-            ["aep_text", "duration_text", "Location", "Type", "trim_runcode"]
-        )["AbsMax"].idxmax()
-    ].reset_index(drop=True)
+    try:
+        aep_dur_max: DataFrame = aggregated_df.loc[
+            aggregated_df.groupby(
+                by=["aep_text", "duration_text", "Location", "Type", "trim_runcode"]
+            )["AbsMax"].idxmax()
+        ].reset_index(drop=True)
+        logger.info(
+            "Created 'aep_dur_max' DataFrame with peak records for each AEP-Duration-Location-Type-RunCode group."
+        )
+    except KeyError as e:
+        logger.error(f"Missing expected columns for 'aep_dur_max' grouping: {e}")
+        aep_dur_max = pd.DataFrame()
+    return aep_dur_max
 
 
 def find_aep_max(aep_dur_max: pd.DataFrame) -> pd.DataFrame:
-    """Return peak rows for each AEP/Location/Type/RunCode group."""
-    return aep_dur_max.loc[
-        aep_dur_max.groupby(["aep_text", "Location", "Type", "trim_runcode"])["AbsMax"].idxmax()
-    ].reset_index(drop=True)
+    try:
+        aep_max: DataFrame = aep_dur_max.loc[
+            aep_dur_max.groupby(["aep_text", "Location", "Type", "trim_runcode"])[
+                "AbsMax"
+            ].idxmax()
+        ].reset_index(drop=True)
+        logger.info("Created 'aep_max' DataFrame with peak records for each AEP group.")
+    except KeyError as e:
+        logger.error(f"Missing expected columns for 'aep_max' grouping: {e}")
+        aep_max = pd.DataFrame()
+    return aep_max
 
 
-def save_to_excel(aep_dur_max: pd.DataFrame, aep_max: pd.DataFrame, output_path: Path) -> None:
+def save_to_excel(
+    aep_dur_max: pd.DataFrame,
+    aep_max: pd.DataFrame,
+    aggregated_df: pd.DataFrame,
+    output_path: Path,
+) -> None:
     """Save peak DataFrames to an Excel file."""
     logger.info(f"Output path: {output_path}")
     with pd.ExcelWriter(output_path) as writer:
-        aep_dur_max.to_excel(writer, sheet_name="aep-dur-max", index=False, merge_cells=False)
-        aep_max.to_excel(writer, sheet_name="aep-max", index=False, merge_cells=False)
+        aep_dur_max.to_excel(
+            excel_writer=writer,
+            sheet_name="aep-dur-max",
+            index=False,
+            merge_cells=False,
+        )
+        aep_max.to_excel(
+            excel_writer=writer, sheet_name="aep-max", index=False, merge_cells=False
+        )
+        aggregated_df.to_excel(
+            excel_writer=writer, sheet_name="POMM", index=False, merge_cells=False
+        )
+
     logger.info(f"Peak data exported to {output_path}")
 
 
@@ -168,9 +225,13 @@ def save_peak_report(
     suffix: str = "_peaks.xlsx",
 ) -> None:
     """Save peak data tables to an Excel file."""
-    aep_dur_max = find_aep_dur_max(aggregated_df)
-    aep_max = find_aep_max(aep_dur_max)
-    output_filename = f"{timestamp}{suffix}"
-    output_path = script_directory / output_filename
-    save_to_excel(aep_dur_max, aep_max, output_path)
-
+    aep_dur_max: DataFrame = find_aep_dur_max(aggregated_df=aggregated_df)
+    aep_max: DataFrame = find_aep_max(aep_dur_max=aep_dur_max)
+    output_filename: str = f"{timestamp}{suffix}"
+    output_path: Path = script_directory / output_filename
+    save_to_excel(
+        aep_dur_max=aep_dur_max,
+        aep_max=aep_max,
+        aggregated_df=aggregated_df,
+        output_path=output_path,
+    )

--- a/ryan_library/scripts/pomm_utils.py
+++ b/ryan_library/scripts/pomm_utils.py
@@ -1,0 +1,176 @@
+"""Utility helpers for processing POMM CSV files."""
+
+from pathlib import Path
+from multiprocessing import Pool
+from typing import Iterable
+
+import pandas as pd
+from loguru import logger
+
+from ryan_library.functions.file_utils import (
+    find_files_parallel,
+    is_non_zero_file,
+)
+from ryan_library.functions.misc_functions import calculate_pool_size
+from ryan_library.processors.tuflow.base_processor import BaseProcessor
+from ryan_library.processors.tuflow.processor_collection import ProcessorCollection
+from ryan_library.classes.suffixes_and_dtypes import SuffixesConfig
+from ryan_library.functions.loguru_helpers import setup_logger, worker_initializer
+
+
+# ---------------------------------------------------------------------------
+# File collection and processing helpers
+# ---------------------------------------------------------------------------
+
+def collect_files(
+    paths_to_process: Iterable[Path],
+    include_data_types: Iterable[str],
+    suffixes_config: SuffixesConfig,
+) -> list[Path]:
+    """Collect and filter files based on suffix configuration."""
+    csv_file_list: list[Path] = []
+    suffixes: list[str] = []
+
+    data_type_to_suffix = suffixes_config.invert_suffix_to_type()
+
+    for data_type in include_data_types:
+        dt_suffixes = data_type_to_suffix.get(data_type)
+        if not dt_suffixes:
+            logger.error(f"No suffixes found for data type '{data_type}'. Skipping.")
+            continue
+        suffixes.extend(dt_suffixes)
+
+    if not suffixes:
+        logger.error("No suffixes found for the specified data types.")
+        return csv_file_list
+
+    patterns = [f"*{suffix}" for suffix in suffixes]
+
+    root_dirs = [p for p in paths_to_process if p.is_dir()]
+    invalid_dirs = set(paths_to_process) - set(root_dirs)
+    for invalid_dir in invalid_dirs:
+        logger.warning(f"Path {invalid_dir} is not a directory. Skipping.")
+
+    matched_files = find_files_parallel(root_dirs=root_dirs, patterns=patterns)
+    csv_file_list.extend(matched_files)
+
+    csv_file_list = [f for f in csv_file_list if is_non_zero_file(f)]
+    return csv_file_list
+
+
+def process_file(file_path: Path) -> BaseProcessor:
+    """Process a single file using the :class:`BaseProcessor` hierarchy."""
+    processor = BaseProcessor.from_file(file_path=file_path)
+    processor.process()
+    if processor.validate_data():
+        logger.info(f"Successfully processed file: {file_path}")
+    else:
+        logger.warning(f"Validation failed for file: {file_path}")
+    return processor
+
+
+def process_files_in_parallel(file_list: list[Path], log_queue) -> ProcessorCollection:
+    """Process files using multiprocessing and return a collection."""
+    pool_size = calculate_pool_size(num_files=len(file_list))
+    logger.info(f"Initializing multiprocessing pool with {pool_size} processes.")
+
+    results_set = ProcessorCollection()
+    with Pool(processes=pool_size, initializer=worker_initializer, initargs=(log_queue,)) as pool:
+        results = pool.map(func=process_file, iterable=file_list)
+
+    for result in results:
+        if result is not None and result.processed:
+            results_set.add_processor(processor=result)
+    return results_set
+
+
+def combine_processors_from_paths(
+    paths_to_process: list[Path],
+    include_data_types: list[str] | None = None,
+    console_log_level: str = "INFO",
+) -> ProcessorCollection:
+    """Return a :class:`ProcessorCollection` for the provided directories."""
+    if include_data_types is None:
+        include_data_types = ["POMM"]
+
+    with setup_logger(console_log_level=console_log_level) as log_queue:
+        logger.info("Starting POMM processing for combine_processors_from_paths.")
+        csv_file_list = collect_files(
+            paths_to_process=paths_to_process,
+            include_data_types=include_data_types,
+            suffixes_config=SuffixesConfig.get_instance(),
+        )
+        if not csv_file_list:
+            logger.info("No valid files found to process.")
+            return ProcessorCollection()
+
+        results_set = process_files_in_parallel(file_list=csv_file_list, log_queue=log_queue)
+
+    return results_set
+
+
+def combine_df_from_paths(
+    paths_to_process: list[Path],
+    include_data_types: list[str] | None = None,
+    console_log_level: str = "INFO",
+) -> pd.DataFrame:
+    """Return an aggregated DataFrame for the given directories."""
+    results_set = combine_processors_from_paths(
+        paths_to_process=paths_to_process,
+        include_data_types=include_data_types,
+        console_log_level=console_log_level,
+    )
+
+    if not results_set.processors:
+        return pd.DataFrame()
+
+    return results_set.pomm_combine()
+
+
+# ---------------------------------------------------------------------------
+# Peak report helpers
+# ---------------------------------------------------------------------------
+
+def aggregated_from_paths(paths: list[Path]) -> pd.DataFrame:
+    """Process directories and return a combined POMM DataFrame."""
+    return combine_df_from_paths(paths_to_process=paths)
+
+
+def find_aep_dur_max(aggregated_df: pd.DataFrame) -> pd.DataFrame:
+    """Return peak rows for each AEP/Duration/Location/Type/RunCode group."""
+    return aggregated_df.loc[
+        aggregated_df.groupby(
+            ["aep_text", "duration_text", "Location", "Type", "trim_runcode"]
+        )["AbsMax"].idxmax()
+    ].reset_index(drop=True)
+
+
+def find_aep_max(aep_dur_max: pd.DataFrame) -> pd.DataFrame:
+    """Return peak rows for each AEP/Location/Type/RunCode group."""
+    return aep_dur_max.loc[
+        aep_dur_max.groupby(["aep_text", "Location", "Type", "trim_runcode"])["AbsMax"].idxmax()
+    ].reset_index(drop=True)
+
+
+def save_to_excel(aep_dur_max: pd.DataFrame, aep_max: pd.DataFrame, output_path: Path) -> None:
+    """Save peak DataFrames to an Excel file."""
+    logger.info(f"Output path: {output_path}")
+    with pd.ExcelWriter(output_path) as writer:
+        aep_dur_max.to_excel(writer, sheet_name="aep-dur-max", index=False, merge_cells=False)
+        aep_max.to_excel(writer, sheet_name="aep-max", index=False, merge_cells=False)
+    logger.info(f"Peak data exported to {output_path}")
+
+
+def save_peak_report(
+    aggregated_df: pd.DataFrame,
+    script_directory: Path,
+    timestamp: str,
+    suffix: str = "_peaks.xlsx",
+) -> None:
+    """Save peak data tables to an Excel file."""
+    aep_dur_max = find_aep_dur_max(aggregated_df)
+    aep_max = find_aep_max(aep_dur_max)
+    output_filename = f"{timestamp}{suffix}"
+    output_path = script_directory / output_filename
+    save_to_excel(aep_dur_max, aep_max, output_path)
+


### PR DESCRIPTION
## Summary
- move POMM processing helpers to `pomm_utils`
- simplify `pomm_combine` to rely on shared utilities
- update `pomm_max_items` and wrappers to use the new workflow

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: FileNotFoundError and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_685784e8e104832e9aae995e85d2e7c6