### PR TITLE
[scripts] show library version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 .mypy_cache/
 pyrightconfig.json
 ryan_functions.egg-info
+
 build/
 %LOCALAPPDATA%
+
+# Local virtual environments
+.venv/
 
 # Ignore everything in the dist folder
 dist/*

--- a/ryan-scripts/TUFLOW-python/POMM_combine.py
+++ b/ryan-scripts/TUFLOW-python/POMM_combine.py
@@ -14,9 +14,7 @@ console_log_level = "INFO"  # or "DEBUG"
 
 def main() -> None:
     """Wrapper script to merge POMM results.
-
-    By default, it processes files in the script's directory.
-    """
+    By default, it processes files in the script's directory."""
     print_library_version()
 
     # Determine the script directory
@@ -25,7 +23,7 @@ def main() -> None:
     #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
     # )
 
-    if not change_working_directory(script_directory):
+    if not change_working_directory(target_dir=script_directory):
         return
 
     main_processing(

--- a/ryan-scripts/TUFLOW-python/POMM_combine.py
+++ b/ryan-scripts/TUFLOW-python/POMM_combine.py
@@ -4,32 +4,30 @@ import os
 from pathlib import Path
 
 from ryan_library.scripts.pomm_combine import main_processing
+from ryan_library.scripts.wrapper_utils import (
+    change_working_directory,
+    print_library_version,
+)
 
-console_log_level = "INFO"  # "DEBUG" "INFO"
+console_log_level = "INFO"  # or "DEBUG"
 
 
 def main() -> None:
-    """Wrapper script to merge POMM results
-    By default, it processes files in the directory where the script is located."""
+    """Wrapper script to merge POMM results.
 
-    try:
-        # Determine the script directory
-        script_directory: Path = Path(__file__).resolve().parent
-        # script_directory = Path(
-        # r"Q:\BGER\PER\RPRT\ryan-tools\tests\test_data\tuflow\tutorials"
-        # r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials"
-        # r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
-        # )
+    By default, it processes files in the script's directory.
+    """
+    print_library_version()
 
-        os.chdir(script_directory)
+    # Determine the script directory
+    script_directory: Path = Path(__file__).resolve().parent
+    # script_directory = Path(
+    #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
+    # )
 
-        # You can pass a list of paths here if needed; default is the script directory
-    except Exception as e:
-        print(f"Failed to change working directory: {e}")
-        os.system("PAUSE")
-        exit(1)
+    if not change_working_directory(script_directory):
+        return
 
-    print(f"Current Working Directory: {Path.cwd()}")
     main_processing(
         paths_to_process=[script_directory],
         include_data_types=["POMM"],

--- a/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py
+++ b/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py
@@ -20,7 +20,7 @@ def main() -> None:
     # script_dir = Path(
     #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
     # )
-    if not change_working_directory(script_dir):
+    if not change_working_directory(target_dir=script_dir):
         return
 
     main_processing(

--- a/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py
+++ b/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py
@@ -1,24 +1,27 @@
 # ryan-scripts\TUFLOW-python\TUFLOW_Culvert_Maximums.py
+
 from pathlib import Path
 import os
-import sys
 
 from ryan_library.scripts.tuflow_culverts_merge import main_processing
+from ryan_library.scripts.wrapper_utils import (
+    change_working_directory,
+    print_library_version,
+)
 
-console_log_level = "DEBUG"  # "INFO"  # or "DEBUG"
+console_log_level = "DEBUG"  # or "INFO"
 
 
 def main() -> None:
     """Wrapper to merge culvert maximums; double-clickable.
-    By default, it processes files in the directory where the script is located."""
-    try:
-        script_dir: Path = Path(__file__).resolve().parent
-        script_dir = Path(r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03")
-        os.chdir(script_dir)
-    except Exception as e:
-        print(f"Failed to cd: {e}")
-        os.system("PAUSE")
-        exit(1)
+    It processes files in the script's directory by default."""
+    print_library_version()
+    script_dir: Path = Path(__file__).resolve().parent
+    # script_dir = Path(
+    #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
+    # )
+    if not change_working_directory(script_dir):
+        return
 
     main_processing(
         paths_to_process=[script_dir],
@@ -30,5 +33,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-    print("end of script")
-    # os.system(command="PAUSE")
+    os.system("PAUSE")

--- a/ryan_library/scripts/wrapper_utils.py
+++ b/ryan_library/scripts/wrapper_utils.py
@@ -1,0 +1,24 @@
+"""Utility functions shared by wrapper scripts."""
+
+from pathlib import Path
+import os
+from importlib.metadata import PackageNotFoundError, version
+
+
+def change_working_directory(target_dir: Path) -> bool:
+    """Change the working directory and handle failures."""
+    try:
+        os.chdir(target_dir)
+    except OSError as exc:
+        print(f"Failed to change working directory to {target_dir}: {exc}")
+        os.system("PAUSE")
+        return False
+    return True
+
+
+def print_library_version(package_name: str = "ryan_functions") -> None:
+    """Display the installed version of *package_name* if available."""
+    try:
+        print(f"{package_name} version: {version(package_name)}")
+    except PackageNotFoundError:
+        print(f"{package_name} version: unknown")


### PR DESCRIPTION
## Summary
- expose helper to report package version
- print version at start of culvert maximums wrapper
- print version at start of POMM combine wrapper

## Testing
- `flake8 ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py ryan-scripts/TUFLOW-python/POMM_combine.py ryan_library/scripts/wrapper_utils.py`
- `mypy --ignore-missing-imports --follow-imports=skip ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py ryan-scripts/TUFLOW-python/POMM_combine.py ryan_library/scripts/wrapper_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685ab9c8b01c832ea5906d7b31324ff9