### PR TITLE
[RORB] Refine closure duration utilities

### DIFF
--- a/ryan-scripts/RORB-python/RORB-find-closure-durations.py
+++ b/ryan-scripts/RORB-python/RORB-find-closure-durations.py
@@ -1,0 +1,22 @@
+"""Example wrapper for computing RORB closure durations.
+
+Update ``paths`` or ``thresholds`` below to customise processing.
+Thresholds default to a broad range of flows when ``None``.
+"""
+
+from pathlib import Path
+import os
+
+from ryan_library.scripts.RORB.closure_durations import run_closure_durations
+
+
+def main() -> None:
+    script_directory = Path(__file__).resolve().parent
+    os.chdir(script_directory)
+    # Edit ``paths`` to point to directories with RORB batch.out files.
+    # ``thresholds`` can also be provided if the default flow list is unsuitable.
+    run_closure_durations(paths=[script_directory], thresholds=None, log_level="INFO")
+
+
+if __name__ == "__main__":
+    main()

--- a/ryan_library/functions/RORB/__init__.py
+++ b/ryan_library/functions/RORB/__init__.py
@@ -1,0 +1,15 @@
+"""Helper functions for reading and analyzing RORB outputs."""
+
+from .read_rorb_files import (
+    find_batch_files,
+    parse_batch_output,
+    read_hydrograph_csv,
+    analyze_hydrograph,
+)
+
+__all__ = [
+    "find_batch_files",
+    "parse_batch_output",
+    "read_hydrograph_csv",
+    "analyze_hydrograph",
+]

--- a/ryan_library/functions/RORB/read_rorb_files.py
+++ b/ryan_library/functions/RORB/read_rorb_files.py
@@ -1,0 +1,135 @@
+import logging
+from pathlib import Path
+from collections.abc import Iterable
+
+import pandas as pd
+
+
+logger = logging.getLogger(__name__)
+
+
+def find_batch_files(paths: Iterable[Path]) -> list[Path]:
+    """Return list of ``batch.out`` files found recursively under ``paths``."""
+    files: list[Path] = []
+    for root in paths:
+        files.extend([p for p in root.rglob("*batch.out") if p.is_file()])
+    return files
+
+
+def _parse_run_line(line: str, batchout_file: Path) -> list[float | int | str] | None:
+    raw = line.strip().split()
+    if len(raw) < 8:
+        logger.warning("Invalid run line skipped: %s", line.strip())
+        return None
+
+    try:
+        raw[3] = raw[3].strip("%")
+        duration_part = raw[1] + raw[2]
+        aep_part = f"aep{raw[3]}"
+        raw[6] = "1" if raw[6].upper() == "Y" else "0"
+        if raw[2].lower() != "hour":
+            raw[1] = str(float(raw[1]) / 60)
+        raw.pop(2)
+        processed_line: list[float | int | str] = []
+        for i, el in enumerate(raw):
+            processed_line.append(int(el) if i in (0, 3) else float(el))
+        csv_path = _construct_csv_path(batchout_file, aep_part, duration_part, int(processed_line[3]))
+        processed_line.append(str(csv_path))
+        return processed_line
+    except Exception as exc:  # pragma: no cover - parsing errors are logged
+        logger.exception("Error parsing run line: %s", line)
+        return None
+
+
+def _construct_csv_path(batchout: Path, aep_part: str, duration_part: str, tpat: int) -> Path:
+    aep = aep_part.replace(".", "p")
+    du = duration_part.replace(".", "_")
+    base_name = batchout.name.replace("batch.out", "")
+    second_part = f" {aep}_du{du}tp{tpat}.csv"
+    return batchout.parent / (base_name + second_part)
+
+
+def parse_batch_output(batchout_file: Path) -> pd.DataFrame:
+    """Return DataFrame describing runs defined in ``batchout_file``."""
+    basename = batchout_file.name
+    rorb_runs: list[list[float | int | str]] = []
+    headers: list[str] = []
+    try:
+        with batchout_file.open("r") as f:
+            found_results = 0
+            for line in f:
+                if found_results == 20:
+                    continue
+                if found_results == 0:
+                    if "Peak  Description" in line:
+                        found_results = 1
+                elif found_results == 1:
+                    if "Run,    Representative hydrograph" in line:
+                        found_results = 20
+                    elif " Run        Duration" in line:
+                        headers = line.strip().split()
+                        headers.append("csv")
+                    else:
+                        run = _parse_run_line(line, batchout_file)
+                        if run:
+                            rorb_runs.append(run)
+        if not rorb_runs or not headers:
+            return pd.DataFrame()
+        df = pd.DataFrame(rorb_runs, columns=headers)
+        df["file"] = basename
+        df["folder"] = str(batchout_file.parent)
+        df["Path"] = str(batchout_file)
+        return df
+    except Exception as exc:  # pragma: no cover - logs handle detail
+        logger.exception("Failed parsing %s", batchout_file)
+        return pd.DataFrame()
+
+
+def read_hydrograph_csv(filepath: Path) -> pd.DataFrame:
+    """Return hydrograph DataFrame from RORB CSV."""
+    try:
+        df = pd.read_csv(filepath, sep=",", skiprows=2, header=0)
+        df.drop(df.columns[0], axis=1, inplace=True)
+        return df
+    except Exception as exc:  # pragma: no cover - file errors
+        logger.exception("Error reading hydrograph %s", filepath)
+        return pd.DataFrame()
+
+
+def analyze_hydrograph(
+    aep: str,
+    duration: str,
+    tp: int,
+    csv_path: Path,
+    out_path: Path,
+    thresholds: list[float],
+) -> pd.DataFrame:
+    """Return durations exceeding ``thresholds`` for a single hydrograph file."""
+    df = read_hydrograph_csv(csv_path)
+    if df.empty:
+        return pd.DataFrame()
+
+    df.columns = [c.replace("Calculated hydrograph:  ", "") for c in df.columns]
+    if "Time (hrs)" not in df.columns or len(df["Time (hrs)"]) < 2:
+        logger.error("Missing 'Time (hrs)' in %s", csv_path)
+        return pd.DataFrame()
+    timestep = df["Time (hrs)"].iloc[1] - df["Time (hrs)"].iloc[0]
+
+    records: list[dict[str, float | str | int]] = []
+    for thresh in thresholds:
+        counts = (df.iloc[:, 1:] > thresh).sum()
+        locations = counts[counts > 0].index.tolist()
+        dur_exc = (counts[counts > 0] * timestep).tolist()
+        for loc, dur_exc_val in zip(locations, dur_exc):
+            records.append(
+                {
+                    "AEP": aep,
+                    "Duration": duration,
+                    "TP": tp,
+                    "Location": loc,
+                    "ThresholdFlow": thresh,
+                    "Duration_Exceeding": dur_exc_val,
+                    "out_path": str(out_path),
+                }
+            )
+    return pd.DataFrame(records)

--- a/ryan_library/functions/pandas/__init__.py
+++ b/ryan_library/functions/pandas/__init__.py
@@ -1,0 +1,3 @@
+from .median_calc import _median_stats_for_group, median_stats, median_calc
+
+__all__ = ["_median_stats_for_group", "median_stats", "median_calc"]

--- a/ryan_library/scripts/RORB/__init__.py
+++ b/ryan_library/scripts/RORB/__init__.py
@@ -1,0 +1,5 @@
+"""Scripts for RORB data processing."""
+
+from .closure_durations import run_closure_durations
+
+__all__ = ["run_closure_durations"]

--- a/ryan_library/scripts/RORB/closure_durations.py
+++ b/ryan_library/scripts/RORB/closure_durations.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+from pathlib import Path
+from collections.abc import Iterable
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from loguru import logger
+
+from ryan_library.functions.RORB.read_rorb_files import (
+    find_batch_files,
+    parse_batch_output,
+    analyze_hydrograph,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ryan_library.functions.loguru_helpers import setup_logger
+else:  # pragma: no cover - runtime dynamic import
+    from importlib import import_module
+
+    setup_logger = import_module("ryan_library.functions.loguru_helpers").setup_logger
+from ryan_library.functions.pandas.median_calc import median_stats as median_stats_func
+
+
+def _collect_batch_data(paths: Iterable[Path]) -> pd.DataFrame:
+    batch_files = find_batch_files(paths)
+    dfs = [parse_batch_output(p) for p in batch_files]
+    dfs = [df for df in dfs if not df.empty]
+    return pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+
+
+def _process_hydrographs(batch_df: pd.DataFrame, thresholds: list[float]) -> pd.DataFrame:
+    records: list[pd.DataFrame] = []
+    for _, row in batch_df.iterrows():
+        rec = analyze_hydrograph(
+            aep=str(row["AEP"]),
+            duration=str(row["Duration"]),
+            tp=int(row["TPat"]),
+            csv_path=Path(row["csv"]),
+            out_path=Path(row["Path"]),
+            thresholds=thresholds,
+        )
+        if not rec.empty:
+            records.append(rec)
+    return pd.concat(records, ignore_index=True) if records else pd.DataFrame()
+
+
+def _summarise_results(df: pd.DataFrame) -> pd.DataFrame:
+    final_columns = [
+        "Path",
+        "Location",
+        "ThresholdFlow",
+        "AEP",
+        "Central_Value",
+        "Critical_Duration",
+        "Critical_Tp",
+        "Low_Value",
+        "High_Value",
+        "Average_Value",
+        "Closest_Tpcrit",
+        "Closest_Value",
+    ]
+    finaldb = pd.DataFrame(columns=final_columns)
+    grouped = df.groupby(["out_path", "Location", "ThresholdFlow", "AEP"])
+    for name, group in grouped:
+        stats, _ = median_stats_func(group, "Duration_Exceeding", "TP", "Duration")
+        row = list(name) + [
+            stats.get("median"),
+            stats.get("Duration"),
+            stats.get("Critical_TP"),
+            stats.get("low"),
+            stats.get("high"),
+            stats.get("mean_including_zeroes"),
+            stats.get("Critical_TP"),
+            stats.get("median"),
+        ]
+        finaldb.loc[len(finaldb)] = row
+    finaldb.columns = final_columns
+    return finaldb
+
+
+def run_closure_durations(
+    paths: Iterable[Path] | None = None,
+    thresholds: list[float] | None = None,
+    log_level: str = "INFO",
+) -> None:
+    """Process ``batch.out`` files under ``paths`` and report closure durations.
+
+    Parameters can be overridden to specify custom folders or flow thresholds.
+    ``paths`` defaults to the current working directory when ``None``.
+    ``thresholds`` defaults to a wide range of increasing flow values.
+    """
+    if paths is None:
+        paths = [Path.cwd()]
+    if thresholds is None:
+        values = list(range(1, 10)) + list(range(10, 100, 2)) + list(range(100, 2100, 10))
+        thresholds = [float(v) for v in values]
+    threshold_values: list[float] = thresholds
+
+    with setup_logger(console_log_level=log_level):
+        batch_df = _collect_batch_data(paths)
+        if batch_df.empty:
+            logger.warning("No batch.out data found.")
+            return
+        result_df = _process_hydrographs(batch_df, threshold_values)
+        if result_df.empty:
+            logger.warning("No hydrograph data processed.")
+            return
+
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M")
+        result_df.to_parquet(f"{timestamp}_durex.parquet.gzip", compression="gzip")
+        result_df.to_csv(f"{timestamp}_durex.csv", index=False)
+        summary_df = _summarise_results(result_df)
+        summary_df.to_csv(f"{timestamp}_QvsTexc.csv", index=False)
+        logger.info("Processing complete")


### PR DESCRIPTION
## Summary
- drop unused median_stats module and fold logic into median_calc
- remove deprecated typing imports and future annotations
- add user hints in wrapper script and docstrings
- provide type-hint compatible interfaces for mypy strict

## Testing
- `black ryan_library/scripts/RORB/closure_durations.py ryan_library/functions/pandas/median_calc.py ryan_library/functions/RORB/read_rorb_files.py ryan_library/functions/pandas/__init__.py ryan-scripts/RORB-python/RORB-find-closure-durations.py -l 120`
- `mypy --follow-imports=skip ryan_library/functions/pandas/median_calc.py ryan_library/functions/RORB/read_rorb_files.py ryan_library/scripts/RORB/closure_durations.py ryan-scripts/RORB-python/RORB-find-closure-durations.py`


------
https://chatgpt.com/codex/tasks/task_e_686e2b3896bc832ea955f64ed963c811