### PR TITLE
[parser] Handle run code trimming case-insensitively

### DIFF
--- a/ryan_library/classes/tuflow_string_classes.py
+++ b/ryan_library/classes/tuflow_string_classes.py
@@ -205,8 +205,10 @@ class TuflowStringParser:
         Returns:
             str: Cleaned run code.
         """
-        components_to_remove = {str(component) for component in [self.aep, self.duration, self.tp] if component}
+        components_to_remove = {str(component).lower() for component in [self.aep, self.duration, self.tp] if component}
         logger.debug(f"Components to remove: {components_to_remove}")
-        trimmed_runcode = "_".join(part for part in self.clean_run_code.split("_") if part not in components_to_remove)
+        trimmed_runcode = "_".join(
+            part for part in self.clean_run_code.split("_") if part.lower() not in components_to_remove
+        )
         logger.debug(f"Trimmed run code: {trimmed_runcode}")
         return trimmed_runcode


### PR DESCRIPTION
## Summary
- trim run codes case-insensitively so TP, AEP, and Duration components are removed regardless of letter case

## Testing
- `python -m mypy ryan_library/classes/tuflow_string_classes.py --follow-imports=skip`
- `python - <<'PY'
from ryan_library.classes.tuflow_string_classes import TuflowStringParser
sample = 'Unity_v05_BigModelDam_EXG_BaseTP_10.0p_04320m_64M_tp06_POMM.csv'
parser = TuflowStringParser(sample)
print('trim_run_code:', parser.trim_run_code)
print('tp_numeric:', parser.tp.numeric_value if parser.tp else None)
print('tp_text:', str(parser.tp) if parser.tp else None)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68be50fe3fb0832e8385c4c5f4386222