### PR TITLE
[tuflow] Detect 1D timeseries via filename

### DIFF
--- a/ryan_library/processors/tuflow/base_processor.py
+++ b/ryan_library/processors/tuflow/base_processor.py
@@ -467,9 +467,10 @@ class BaseProcessor(ABC):
 
         Returns:
             pd.DataFrame: The reshaped DataFrame."""
-        category_type = "Chan ID" if "1d" in self.name_parser.suffixes else "Location"
+        is_1d: bool = "_1d_" in self.file_name.lower()
+        category_type: str = "Chan ID" if is_1d else "Location"
         logger.debug(
-            f"{'1d' in self.name_parser.suffixes and 'Chan ID' or 'Location'} suffix detected; using '{category_type}' as category type."
+            f"{self.file_name}: {'1D' if is_1d else '2D'} filename detected; using '{category_type}' as category type."
         )
 
         try:


### PR DESCRIPTION
## Summary
- derive timeseries category type from `_1d_` in filename instead of suffix list
- log whether filename indicates 1D or 2D data

## Testing
- `python -m black ryan_library/processors/tuflow/base_processor.py`
- `python -m mypy ryan_library/processors/tuflow/base_processor.py --ignore-missing-imports --follow-imports=skip` *(fails: Returning Any from function declared to return `type[BaseProcessor]`; Missing type parameters for generic type `list`)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fc82b228832e8137623a6b7526b1