### PR TITLE
[scripts] Use absolute paths for script directories

### DIFF
--- a/installer-if-no-batch.py
+++ b/installer-if-no-batch.py
@@ -7,7 +7,7 @@ import glob
 def main() -> None:
     try:
         # Define the working path
-        script_dir: Path = Path(__file__).parent.resolve()
+        script_dir: Path = Path(__file__).absolute().parent
         package_dir: Path = script_dir / "dist"
         print(f"PACKAGE_DIR: {package_dir}")
 
@@ -29,9 +29,7 @@ def main() -> None:
         print(f'Installing or updating "{Path(latest_package).name}"')
 
         # Install or update the package using pip
-        result = subprocess.run(
-            [sys.executable, "-m", "pip", "install", "--upgrade", latest_package]
-        )
+        result = subprocess.run([sys.executable, "-m", "pip", "install", "--upgrade", latest_package])
 
         # Check if the installation was successful
         if result.returncode == 0:

--- a/ryan-scripts/12D-python/tif-to-LAS-valid-only_v6.py
+++ b/ryan-scripts/12D-python/tif-to-LAS-valid-only_v6.py
@@ -20,9 +20,7 @@ def save_tile_las(tile_df, output_dir, base_filename, i, j) -> None:
         header = laspy.LasHeader(point_format=3, version="1.2")
 
         # Set scales and offsets based on tile data
-        header.offsets = np.array(
-            [tile_df["X"].min(), tile_df["Y"].min(), tile_df["Z"].min()]
-        )
+        header.offsets = np.array([tile_df["X"].min(), tile_df["Y"].min(), tile_df["Z"].min()])
         header.scales = np.array([0.01, 0.01, 0.01])  # Adjust scales as needed
 
         # Create LasData object
@@ -73,9 +71,7 @@ def save_full_las(df, output_dir, base_filename):
 
 def main() -> None:
     # Set up logging
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
     logger = logging.getLogger(__name__)
     logger.info("Starting LAS terrain data processing script.")
 
@@ -85,7 +81,7 @@ def main() -> None:
     use_tiling = True  # Set to True to enable tiling
 
     # Set script_dir to a specific path
-    script_dir = Path(__file__).resolve().parent
+    script_dir = Path(__file__).absolute().parent
     script_dir = Path(
         r"P:\BGER\PER\RP20180.365 BLACKSMITH SCOPING STUDY - FMG\5 CADD\1 MOD\2 CI\12D\Input\2025.06.20_ClippedGIS\h_hr_max"
     )

--- a/ryan-scripts/12D-python/tif-to-csv-valid-only_v6.py
+++ b/ryan-scripts/12D-python/tif-to-csv-valid-only_v6.py
@@ -58,7 +58,7 @@ def main():
     use_tiling = True  # Set to True to enable tiling
 
     # Set script_dir to a specific path
-    script_dir = Path(__file__).resolve().parent
+    script_dir = Path(__file__).absolute().parent
     logger.info(f"Script directory: {script_dir}")
 
     # Verify that script_dir exists

--- a/ryan-scripts/12D-python/tif-to-csv-valid-only_v6a.py
+++ b/ryan-scripts/12D-python/tif-to-csv-valid-only_v6a.py
@@ -64,7 +64,7 @@ def main():
     use_tiling = False  # Set to True to enable tiling
 
     # Set script_dir to a specific path
-    script_dir = Path(__file__).resolve().parent
+    script_dir = Path(__file__).absolute().parent
     logger.info(f"Script directory: {script_dir}")
 
     # Verify that script_dir exists

--- a/ryan-scripts/RORB-python/RORB-find-closure-durations.py
+++ b/ryan-scripts/RORB-python/RORB-find-closure-durations.py
@@ -17,7 +17,7 @@ console_log_level = "INFO"
 
 def main() -> None:
     print_library_version()
-    script_directory: Path = Path(__file__).resolve().parent
+    script_directory: Path = Path(__file__).absolute().parent
     # script_directory = Path(r"...")
     if not change_working_directory(target_dir=script_directory):
         return

--- a/ryan-scripts/RORB-python/closure_period_RORB_TUFLOW_v9.py
+++ b/ryan-scripts/RORB-python/closure_period_RORB_TUFLOW_v9.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import re
 import csv
 import pandas as pd
@@ -21,9 +22,7 @@ from ryan_functions.processTScsv import processTScsv
 
 
 # Setup logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def read_rorb_data(filepath):
@@ -282,9 +281,7 @@ def create_finaldb(df):
         # Apply the function
         results = grouped.apply(apply_stats).reset_index()
         # Concatenate the results
-        finaldb = pd.concat(
-            [results.drop(columns=0), results[0].apply(pd.Series)], axis=1
-        )
+        finaldb = pd.concat([results.drop(columns=0), results[0].apply(pd.Series)], axis=1)
         finaldb.columns = [
             "TrimRC",
             "location",
@@ -312,7 +309,7 @@ def main():
     """
     try:
         # Set working directory
-        script_dir = os.path.dirname(os.path.realpath(__file__))
+        script_dir = Path(__file__).absolute().parent
         os.chdir(script_dir)
         # Collect input files
         data_types = ["RORB", "TUFLOWPO", "TUFLOW1D"]

--- a/ryan-scripts/RORB-python/hydrograph_extract_rorb_csv.py
+++ b/ryan-scripts/RORB-python/hydrograph_extract_rorb_csv.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pandas as pd
 from datetime import datetime
 import re
@@ -8,9 +9,7 @@ import matplotlib.ticker as ticker
 
 # --- User Configuration ---
 # Specify the hydrograph to process. Set to None to trigger dynamic selection.
-selected_hydrograph = (
-    "Calculated hydrograph:  Outlet"  # Example: "Calculated hydrograph: Outlet"
-)
+selected_hydrograph = "Calculated hydrograph:  Outlet"  # Example: "Calculated hydrograph: Outlet"
 # --- End of User Configuration ---
 
 
@@ -54,9 +53,7 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
     """
     # Precompile regex patterns for efficiency
     regex_patterns = {
-        (aep, tp): re.compile(
-            rf"{re.escape(aep)}_du12hour{re.escape(tp)}\b", re.IGNORECASE
-        )
+        (aep, tp): re.compile(rf"{re.escape(aep)}_du12hour{re.escape(tp)}\b", re.IGNORECASE)
         for aep, tp in selected_combinations
     }
 
@@ -103,9 +100,7 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
         df.columns = [col.strip() for col in df.columns]
 
         # Identify hydrograph columns (excluding 'Inc' and 'Time (hrs)')
-        hydrograph_columns = [
-            col for col in df.columns if col not in ["Inc", "Time (hrs)"]
-        ]
+        hydrograph_columns = [col for col in df.columns if col not in ["Inc", "Time (hrs)"]]
 
         if len(hydrograph_columns) == 0:
             print(f"No hydrograph columns found in {file_name}. Skipping.")
@@ -126,24 +121,18 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
                 print(
                     "Please specify the desired hydrograph by setting the 'selected_hydrograph' variable in the script."
                 )
-                print(
-                    "Example: selected_hydrograph = 'Calculated hydrograph: Outlet'\n"
-                )
+                print("Example: selected_hydrograph = 'Calculated hydrograph: Outlet'\n")
                 sys.exit(1)  # Exit the script with an error code
 
             elif selected_hydrograph not in hydrograph_columns:
-                print(
-                    f"\nError: The specified hydrograph '{selected_hydrograph}' is not found in {file_name}."
-                )
+                print(f"\nError: The specified hydrograph '{selected_hydrograph}' is not found in {file_name}.")
                 print(
                     "Please update the 'selected_hydrograph' variable with a valid hydrograph name from the list above.\n"
                 )
                 sys.exit(1)
 
             else:
-                selected_column = (
-                    selected_hydrograph  # Use the user-specified hydrograph
-                )
+                selected_column = selected_hydrograph  # Use the user-specified hydrograph
 
         # Extract relevant data
         try:
@@ -168,9 +157,7 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
         # Extract metadata from filename
         creek_name, aep, duration, tp = extract_metadata_from_filename(file_name)
         if not all([creek_name, aep, duration, tp]):
-            print(
-                f"Warning: Unable to extract metadata from {file_name}. Setting as 'Unknown'."
-            )
+            print(f"Warning: Unable to extract metadata from {file_name}. Setting as 'Unknown'.")
             creek_name = creek_name or "Unknown_Creek"
             aep = aep or "Unknown_AEP"
             duration = duration or "Unknown_Duration"
@@ -233,9 +220,7 @@ def create_plot(combined_df, aep_mapping, creek_name, script_directory):
         # Sort AEPs based on percentage for ordered legend
         sorted_aeps = sorted(
             aep_mapping.keys(),
-            key=lambda x: (
-                int(re.search(r"\d+", x).group()) if re.search(r"\d+", x) else 0
-            ),
+            key=lambda x: (int(re.search(r"\d+", x).group()) if re.search(r"\d+", x) else 0),
         )
 
         for aep in sorted_aeps:
@@ -294,7 +279,7 @@ def create_plot(combined_df, aep_mapping, creek_name, script_directory):
 
 def main():
     # Get the directory where the script is located
-    script_directory = os.path.dirname(os.path.abspath(__file__))
+    script_directory = Path(__file__).absolute().parent
 
     # Define specific combinations of AEP and TP to process
     selected_combinations = [
@@ -307,9 +292,7 @@ def main():
     ]
 
     # Import and aggregate data
-    combined_df, aep_mapping, creek_name = import_data(
-        script_directory, selected_combinations, selected_hydrograph
-    )
+    combined_df, aep_mapping, creek_name = import_data(script_directory, selected_combinations, selected_hydrograph)
 
     # Save combined data to a single-sheet Excel file
     try:
@@ -321,9 +304,7 @@ def main():
         output_file_path = os.path.join(script_directory, output_file_name)
 
         # Save to Excel with a single sheet
-        combined_df.to_excel(
-            output_file_path, index=False, sheet_name="Hydrograph Data"
-        )
+        combined_df.to_excel(output_file_path, index=False, sheet_name="Hydrograph Data")
         print(f"Combined hydrograph data saved to: {output_file_path}")
     except Exception as e:
         print(f"Error saving combined Excel file: {e}")

--- a/ryan-scripts/RORB-python/rorb-peaks_v2.py
+++ b/ryan-scripts/RORB-python/rorb-peaks_v2.py
@@ -6,11 +6,11 @@ import math
 from functools import reduce
 
 # Set script to run in the folder it is saved in
-script_dir = Path(__file__).resolve().parent
+script_dir = Path(__file__).absolute().parent
 os.chdir(script_dir)
 
 # Identify all .out files in the directory and subdirectories
-out_files = list(script_dir.rglob('*.out'))
+out_files = list(script_dir.rglob("*.out"))
 
 # Check if any .out files are found
 if not out_files:
@@ -27,7 +27,7 @@ skipped_count = 0
 for file_path in out_files:
     # Read the file content
     try:
-        with open(file_path, 'r', encoding='latin1') as file:
+        with open(file_path, "r", encoding="latin1") as file:
             lines = file.readlines()
     except Exception:
         # If there's an error reading the file, skip it
@@ -45,22 +45,22 @@ for file_path in out_files:
         if "Parameters:  kc =" in line:
             params = re.findall(r"[-+]?\d*\.\d+|\d+", line)
             if len(params) >= 2:
-                parameters['kc'] = float(params[0])
-                parameters['m'] = float(params[1])
+                parameters["kc"] = float(params[0])
+                parameters["m"] = float(params[1])
         elif "Initial loss (mm)" in line:
             params = re.findall(r"[-+]?\d*\.\d+|\d+", line)
             if len(params) >= 2:
-                parameters['Initial_loss_mm'] = float(params[0])
-                parameters['Cont_loss_mm_per_h'] = float(params[1])
+                parameters["Initial_loss_mm"] = float(params[0])
+                parameters["Cont_loss_mm_per_h"] = float(params[1])
 
         # Locate the header line and store the header index
         if "Run        Duration             AEP" in line:
             header_index = i
-            headers = re.split(r'\s{2,}', line.strip())
+            headers = re.split(r"\s{2,}", line.strip())
 
         # Collect data rows after the header is found
         if header_index is not None and i > header_index:
-            data_line = re.split(r'\s{2,}', line.strip())
+            data_line = re.split(r"\s{2,}", line.strip())
             if len(data_line) == len(headers):
                 data_rows.append(data_line)
 
@@ -73,13 +73,13 @@ for file_path in out_files:
     df = pd.DataFrame(data_rows, columns=headers)
 
     # Convert numeric columns to appropriate types, excluding specified non-numeric columns
-    non_numeric_columns = ['Run', 'Duration', 'AEP', 'TPat']
+    non_numeric_columns = ["Run", "Duration", "AEP", "TPat"]
     for col in df.columns:
         if col not in non_numeric_columns:
-            df[col] = pd.to_numeric(df[col], errors='coerce')
+            df[col] = pd.to_numeric(df[col], errors="coerce")
 
     # Identify Peak columns (assuming they start with 'Peak')
-    peak_columns = [col for col in df.columns if col.startswith('Peak')]
+    peak_columns = [col for col in df.columns if col.startswith("Peak")]
     if not peak_columns:
         skipped_count += 1
         continue  # Skip to the next file
@@ -95,25 +95,25 @@ for file_path in out_files:
         # Sort the group by the specified Peak column in ascending order
         sorted_group = group.sort_values(by=peak_col, ascending=True).reset_index(drop=True)
         n = len(sorted_group)
-        
+
         # Calculate the index for the higher median
         # For n=10, median_index=5 (6th element)
         # For n=9, median_index=4 (5th element)
         median_index = n // 2  # Integer division
-        
+
         # Handle cases where the group might be empty
         if n == 0:
-            return pd.Series({'Median_Peak': None, 'Median_TPat': None})
-        
+            return pd.Series({"Median_Peak": None, "Median_TPat": None})
+
         # Retrieve the Median_Peak and corresponding TPat
         try:
             median_peak = sorted_group.iloc[median_index][peak_col]
-            median_tpat = sorted_group.iloc[median_index]['TPat']
+            median_tpat = sorted_group.iloc[median_index]["TPat"]
         except IndexError:
             median_peak = None
             median_tpat = None
-        
-        return pd.Series({'Median_Peak': median_peak, 'Median_TPat': median_tpat})
+
+        return pd.Series({"Median_Peak": median_peak, "Median_TPat": median_tpat})
 
     # Initialize an empty list to collect median data for all Peak columns
     median_data = []
@@ -121,16 +121,17 @@ for file_path in out_files:
     # Iterate over each Peak column to compute median and corresponding TPat
     for peak_col in peak_columns:
         # Select only the Peak column and 'TPat' for the apply function to exclude grouping columns
-        median_df = df.groupby(['Duration', 'AEP'])[[peak_col, 'TPat']].apply(
-            get_higher_median_tpat, peak_col=peak_col
-        ).reset_index()
-        
+        median_df = (
+            df.groupby(["Duration", "AEP"])[[peak_col, "TPat"]]
+            .apply(get_higher_median_tpat, peak_col=peak_col)
+            .reset_index()
+        )
+
         # Rename the columns to include the Peak column name
-        median_df.rename(columns={
-            'Median_Peak': f'Median_{peak_col}',
-            'Median_TPat': f'Median_TPat_{peak_col}'
-        }, inplace=True)
-        
+        median_df.rename(
+            columns={"Median_Peak": f"Median_{peak_col}", "Median_TPat": f"Median_TPat_{peak_col}"}, inplace=True
+        )
+
         # Add the Peak column name to the list for merging
         median_data.append(median_df)
 
@@ -138,18 +139,20 @@ for file_path in out_files:
     if len(median_data) == 1:
         final_median_df = median_data[0]
     else:
-        final_median_df = reduce(lambda left, right: pd.merge(left, right, on=['Duration', 'AEP'], how='outer'), median_data)
+        final_median_df = reduce(
+            lambda left, right: pd.merge(left, right, on=["Duration", "AEP"], how="outer"), median_data
+        )
 
     # Add the extracted parameters as new columns to the median dataframe
     for key, value in parameters.items():
         final_median_df[key] = value
 
     # Add the filename as a new column
-    final_median_df['Filename'] = file_path.name
+    final_median_df["Filename"] = file_path.name
 
     # Extract additional RunCode parts from the filename
     run_code = file_path.stem  # Get the filename without extension
-    run_parts = run_code.replace(" ", "_").split("_") 
+    run_parts = run_code.replace(" ", "_").split("_")
     for num, part in enumerate(run_parts):
         # Add 'r0', 'r1', etc. as new columns at the end
         final_median_df[f"r{num}"] = str(part)
@@ -159,17 +162,19 @@ for file_path in out_files:
         relative_path = file_path.parent.relative_to(script_dir).as_posix()
     except ValueError:
         # If file is in the script_dir itself
-        relative_path = '.'
+        relative_path = "."
 
     # Add 'Relative_Path' as a new column
-    final_median_df['Relative_Path'] = relative_path
+    final_median_df["Relative_Path"] = relative_path
 
     # Reorder columns for better readability (optional)
     # Place 'Filename', 'Relative_Path', 'Duration' and 'AEP' first, followed by medians, parameters, and then 'r*' columns
-    median_columns = [col for col in final_median_df.columns if col.startswith('Median_')]
+    median_columns = [col for col in final_median_df.columns if col.startswith("Median_")]
     parameter_columns = list(parameters.keys())
-    r_columns = [col for col in final_median_df.columns if col.startswith('r')]
-    final_columns_order = ['Filename', 'Relative_Path', 'Duration', 'AEP'] + median_columns + parameter_columns + r_columns
+    r_columns = [col for col in final_median_df.columns if col.startswith("r")]
+    final_columns_order = (
+        ["Filename", "Relative_Path", "Duration", "AEP"] + median_columns + parameter_columns + r_columns
+    )
     final_median_df = final_median_df[final_columns_order]
 
     # Append the processed DataFrame to the list
@@ -186,7 +191,7 @@ if not all_median_data:
 combined_median_df = pd.concat(all_median_data, ignore_index=True)
 
 # Export the combined DataFrame to a CSV file
-output_path = 'processed_output.csv'
+output_path = "processed_output.csv"
 combined_median_df.to_csv(output_path, index=False)
 
 # Print summary of processing

--- a/ryan-scripts/TUFLOW-python/LogSummary.py
+++ b/ryan-scripts/TUFLOW-python/LogSummary.py
@@ -14,7 +14,7 @@ def main() -> None:
     print_library_version()
     console_log_level = "INFO"  # or "DEBUG"
     # Determine the script directory
-    script_directory: Path = Path(__file__).resolve().parent
+    script_directory: Path = Path(__file__).absolute().parent
     # script_directory = Path(
     #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
     # )

--- a/ryan-scripts/TUFLOW-python/POMM-med-max-aep-dur.py
+++ b/ryan-scripts/TUFLOW-python/POMM-med-max-aep-dur.py
@@ -14,7 +14,7 @@ def main() -> None:
     print_library_version()
     console_log_level = "INFO"  # or "DEBUG"
     # Determine the script directory
-    script_directory: Path = Path(__file__).resolve().parent
+    script_directory: Path = Path(__file__).absolute().parent
     # script_directory = Path(
     #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
     # )

--- a/ryan-scripts/TUFLOW-python/POMM_combine.py
+++ b/ryan-scripts/TUFLOW-python/POMM_combine.py
@@ -16,7 +16,7 @@ def main() -> None:
     print_library_version()
 
     # Determine the script directory
-    script_directory: Path = Path(__file__).resolve().parent
+    script_directory: Path = Path(__file__).absolute().parent
     # script_directory = Path(
     #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
     # )

--- a/ryan-scripts/TUFLOW-python/TUFLOW-find-closure-durations.py
+++ b/ryan-scripts/TUFLOW-python/TUFLOW-find-closure-durations.py
@@ -20,7 +20,7 @@ console_log_level = "INFO"
 
 def main() -> None:
     print_library_version()
-    script_directory: Path = Path(__file__).resolve().parent
+    script_directory: Path = Path(__file__).absolute().parent
     # script_directory = Path(r"...")
     if not change_working_directory(target_dir=script_directory):
         return

--- a/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py
+++ b/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Maximums.py
@@ -15,7 +15,7 @@ def main() -> None:
     It processes files in the script's directory by default."""
     print_library_version()
     console_log_level = "DEBUG"  # or "INFO"
-    script_dir: Path = Path(__file__).resolve().parent
+    script_dir: Path = Path(__file__).absolute().parent
     # script_dir = Path(
     #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
     # )

--- a/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Timeseries.py
+++ b/ryan-scripts/TUFLOW-python/TUFLOW_Culvert_Timeseries.py
@@ -16,7 +16,7 @@ def main() -> None:
     By default, it processes files in the directory where the script is located."""
     print_library_version()
     console_log_level = "INFO"
-    script_dir: Path = Path(__file__).resolve().parent
+    script_dir: Path = Path(__file__).absolute().parent
     # script_dir = Path(
     #     r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials\Module_03"
     # )

--- a/ryan-scripts/TUFLOW-python/in-progress/closure_tuflow_1D_v8a.py
+++ b/ryan-scripts/TUFLOW-python/in-progress/closure_tuflow_1D_v8a.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from datetime import datetime
 import pandas as pd
 import re
@@ -7,9 +8,7 @@ import csv
 
 
 def setup_logging():
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def processTScsv(file):
@@ -34,9 +33,7 @@ def processTScsv(file):
         3	0.016667	0	0	0	0 """
 
         val_type = csvdata[0][2].split(" ")[0]
-        chan_list = [
-            c.split("[")[0].removeprefix(f"{val_type} ") for c in csvdata[0][2:]
-        ]
+        chan_list = [c.split("[")[0].removeprefix(f"{val_type} ") for c in csvdata[0][2:]]
         # print(val_type, chan_list)
         # the channel might have a space in it so remove both sides with some extra string logic when looking on row A.
         # not going to bother grabbing the type or internal name each time - it should be identical unless someone has manually merged files.
@@ -64,9 +61,7 @@ def processTScsv(file):
                 for enum, val in enumerate(line[2:], start=0):
                     # we can use the enumerate index to read from the chan_list which will be in the same order
                     # ['Chan_ID', 'Time', val_type]
-                    adj_data.append(
-                        [chan_list[enum].strip(), line[1].strip(), val.strip()]
-                    )
+                    adj_data.append([chan_list[enum].strip(), line[1].strip(), val.strip()])
                     # print(adj_data[-1])
         elif val_type in ["H"]:  # two columns and has .1 .2
             adj_data = [["Chan ID", "Time", "H_US", "H_DS"]]
@@ -102,8 +97,8 @@ def processTScsv(file):
         dfData["path"] = file
         dfData["file"] = fileName
         # print(dfData)
-        if 'Time (h)' in dfData.columns:
-            dfData['Time'] = dfData['Time (h)']        
+        if "Time (h)" in dfData.columns:
+            dfData["Time"] = dfData["Time (h)"]
         col_names = {
             "Chan ID": "string",
             "Time": "float64",
@@ -211,9 +206,7 @@ def read_csv(filepathname, separator, skip_row, header_row, skip_cols):
 
         if file_type == "PO":
             search_entry = "Flow"
-            column_numbers = [
-                i for i, column in enumerate(first_row) if column == search_entry
-            ]
+            column_numbers = [i for i, column in enumerate(first_row) if column == search_entry]
             column_numbers.append(1)  # Always skip the first column
         else:
             column_numbers = list(range(len(first_row)))
@@ -228,9 +221,10 @@ def read_csv(filepathname, separator, skip_row, header_row, skip_cols):
         usecols=column_numbers,
     )
 
-
     # Extract value type from the CSV data
-    val_type = first_row[2].split(" ")[0]  # Assuming the value type is determined from the third column in the first row
+    val_type = first_row[2].split(" ")[
+        0
+    ]  # Assuming the value type is determined from the third column in the first row
 
     # Transform column names
     new_column_names = [c.split("[")[0].removeprefix(f"{val_type} ") for c in returncsv.columns]
@@ -238,21 +232,19 @@ def read_csv(filepathname, separator, skip_row, header_row, skip_cols):
     # Rename columns in the DataFrame
     returncsv.columns = new_column_names
 
-
     # print(returncsv.columns)
 
-    if 'Time (h)' in returncsv.columns:
-        returncsv.rename(columns={'Time (h)': 'Time'}, inplace=True)
+    if "Time (h)" in returncsv.columns:
+        returncsv.rename(columns={"Time (h)": "Time"}, inplace=True)
 
     # Skip columns if required
     # if skip_cols > 0:
     #     returncsv.drop(returncsv.columns[:skip_cols], axis=1, inplace=True)
 
-
-
     return returncsv
 
-#old stats
+
+# old stats
 # def stats(freqdb, statcol, tpcol, durcol):
 #     # this function will extract min, max and median peak for peaks in the dataframe and also return corresponding event/scenario and relevant _PO.csv file
 #     # sourced from Animesh orginal style
@@ -273,6 +265,7 @@ def read_csv(filepathname, separator, skip_row, header_row, skip_cols):
 #             low = ensemblestat[statcol].iloc[0]
 #             high = ensemblestat[statcol].iloc[-1]
 #     return [median, Tcrit, Tpcrit, low, high]
+
 
 def stats(freqdb, statcol, tpcol, durcol):
     """
@@ -313,8 +306,6 @@ def stats(freqdb, statcol, tpcol, durcol):
 
     # Return the calculated statistics
     return [median, Tcrit, Tpcrit, low, high]
-
-
 
 
 def calcNumWorkersCores(numFiles):
@@ -478,22 +469,17 @@ def process_hydrographCSV(params_dict):
             "Runcode",
         ]
     )
-    hydrographs = read_csv(
-        filepathname=csv_read, separator=",", skip_row=[0], header_row=0, skip_cols=1
-    )
+    hydrographs = read_csv(filepathname=csv_read, separator=",", skip_row=[0], header_row=0, skip_cols=1)
     # this has time as the first column then location+flows after
     # read_csv(filepathname, separator, skip_row, header_row, skip_cols)
     # this was for rorb - we just get the location names back now.
     #  hydrographs.columns = [
     #     m.replace('Calculated hydrograph:  ', '') for m in list(hydrographs.columns)]
-    
+
     timestep = hydrographs["Time"][1] - hydrographs["Time"][0]
     for qch in qcheckList:
         location = hydrographs[hydrographs > qch].count()[1:].index.to_list()
-        dur_exc = [
-            (k + int(k > 0)) * timestep
-            for k in hydrographs[hydrographs > qch].count()[1:]
-        ]
+        dur_exc = [(k + int(k > 0)) * timestep for k in hydrographs[hydrographs > qch].count()[1:]]
         dictionary = {
             "AEP": [aep] * len(location),
             "Duration": [dur] * len(location),
@@ -548,6 +534,7 @@ def search_csv_files(search_term="**/*_PO.csv"):
 
 def make_file_list(searchString):
     from glob import iglob
+
     textString = r"**/*" + searchString
     print(f"Recursively searching for {textString} files - can take a while")
     file_list = [f for f in iglob(textString, recursive=True) if os.path.isfile(f)]
@@ -565,16 +552,12 @@ def process_file_list(file_list):
     # Split file_list for multiprocessing
     num_processes = multiprocessing.cpu_count()  # Or set a specific number
     chunk_size = len(file_list) // num_processes
-    files_chunks = [
-        file_list[i : i + chunk_size] for i in range(0, len(file_list), chunk_size)
-    ]
+    files_chunks = [file_list[i : i + chunk_size] for i in range(0, len(file_list), chunk_size)]
 
     # Ensure the worker function can access the duration_skip list
     with multiprocessing.Pool(processes=num_processes) as pool:
         # Map each file chunk to the process_files function
-        result_lists = pool.starmap(
-            process_files, [(chunk, duration_skip) for chunk in files_chunks]
-        )
+        result_lists = pool.starmap(process_files, [(chunk, duration_skip) for chunk in files_chunks])
 
     # Combine the results
     combined_results = []
@@ -586,9 +569,7 @@ def process_file_list(file_list):
 
 
 def output_file_list(files_df):
-    DateTimeString = (
-        datetime.now().strftime("%Y%m%d") + "-" + datetime.now().strftime("%H%M")
-    )
+    DateTimeString = datetime.now().strftime("%Y%m%d") + "-" + datetime.now().strftime("%H%M")
     output = f"{DateTimeString}_PO_list.csv"
     print(f"Outputting file list: {output}")
     files_df.to_csv(output, index=False)
@@ -678,16 +659,15 @@ def merge_data(DATA):
     # # print(q.head())
     # df.append(q)
 
-    DateTimeString = (
-        datetime.now().strftime("d%Y%m%d") + "-" + datetime.now().strftime("%H%M")
-    )
+    DateTimeString = datetime.now().strftime("d%Y%m%d") + "-" + datetime.now().strftime("%H%M")
     output = f"{DateTimeString}_durex"
     df.to_parquet(f"{output}.parquet.gzip")
     # df.to_csv(f"{output}.csv", index=False)
 
     return df
 
-#old create_finaldb
+
+# old create_finaldb
 # def create_finaldb(df):
 #     finaldb = pd.DataFrame(
 #         columns=[
@@ -741,6 +721,7 @@ def create_finaldb(df):
     grouped = df.groupby(["TrimRC", "Location", "ThresholdFlow", "AEP"])
 
     print("Applying the stats function to each group...")
+
     # Define a function to be applied to each group
     def apply_stats(group):
         return stats(group, "Duration_Exceeding", "TP", "Duration")
@@ -752,9 +733,15 @@ def create_finaldb(df):
     # Concatenate the results
     finaldb = pd.concat([results.drop(columns=0), results[0].apply(pd.Series)], axis=1)
     finaldb.columns = [
-        "TrimRC", "location", "Threshold_Q", "AEP", 
-        "Duration_Exceeded", "Critical_Storm", "Critical_Tp", 
-        "Low_Duration", "High_Duration"
+        "TrimRC",
+        "location",
+        "Threshold_Q",
+        "AEP",
+        "Duration_Exceeded",
+        "Critical_Storm",
+        "Critical_Tp",
+        "Low_Duration",
+        "High_Duration",
     ]
 
     # Save the dataframe to a CSV file
@@ -780,9 +767,7 @@ def plot_data(df, working_dir):
     # rorb
     # max_df=db.groupby(['Location','AEP','ThresholdFlow','out_path'])['Duration_Exceeding'].max()
     # tuflow
-    max_df = db.groupby(["Location", "AEP", "ThresholdFlow", "TrimRC"])[
-        "Duration_Exceeding"
-    ].max()
+    max_df = db.groupby(["Location", "AEP", "ThresholdFlow", "TrimRC"])["Duration_Exceeding"].max()
     plot_table = max_df.reset_index()
     # plot_table.loc[plot_table['Location'] == 'Chinnamon Creek']
 
@@ -829,6 +814,6 @@ def main():
 
 
 if __name__ == "__main__":
-    script_dir = os.path.dirname(os.path.realpath(__file__))
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     main()

--- a/ryan-scripts/TUFLOW-python/in-progress/closure_tuflow_v7b.py
+++ b/ryan-scripts/TUFLOW-python/in-progress/closure_tuflow_v7b.py
@@ -23,12 +23,7 @@ SKIP_ROW = [0]
 HEADER_ROW = 0
 SKIP_COLS = 1
 DURATION_SKIP_LIST = []  # Example: ['5760', '7200', '8640', '10080']
-QC_CHECK_LIST = (
-    list(range(2, 30, 1))
-    + list(range(30, 100, 5))
-    + list(range(100, 500, 20))
-    + list(range(500, 2100, 50))
-)
+QC_CHECK_LIST = list(range(2, 30, 1)) + list(range(30, 100, 5)) + list(range(100, 500, 20)) + list(range(500, 2100, 50))
 
 # Initialize logging using the existing setup
 setup_logging()
@@ -52,9 +47,7 @@ class PODetails:
     run_params: dict[str, str] = field(default_factory=dict)
 
 
-def read_csv(
-    filepath: Path, separator: str, skip_row: list[int], header_row: int, skip_cols: int
-) -> pd.DataFrame:
+def read_csv(filepath: Path, separator: str, skip_row: list[int], header_row: int, skip_cols: int) -> pd.DataFrame:
     """
     Reads a CSV file and extracts the 'Flow' columns along with 'Time'.
 
@@ -73,9 +66,7 @@ def read_csv(
         with filepath.open("r") as file:
             reader = csv.reader(file)
             first_row = next(reader)
-            flow_columns = [
-                i for i, column in enumerate(first_row) if column == search_entry
-            ]
+            flow_columns = [i for i, column in enumerate(first_row) if column == search_entry]
             if not flow_columns:
                 logger.warning(f"No 'Flow' columns found in {filepath}.")
             # Always include the 'Time' column (assuming it's the second column, index 1)
@@ -103,9 +94,7 @@ def read_csv(
         return pd.DataFrame()
 
 
-def stats(
-    freqdb: pd.DataFrame, statcol: str, tpcol: str, durcol: str
-) -> list[Optional[Any]]:
+def stats(freqdb: pd.DataFrame, statcol: str, tpcol: str, durcol: str) -> list[Optional[Any]]:
     """
     Extracts statistical metrics from the frequency database.
 
@@ -238,9 +227,7 @@ def process_hydrographCSV(params_dict: dict[str, Any]) -> Optional[pd.DataFrame]
             return None
         qcheckList = params_dict["qc"]
 
-        logger.debug(
-            f"Processing hydrograph: AEP={aep}, Duration={dur}, TP={tp}, CSV={csv_read}"
-        )
+        logger.debug(f"Processing hydrograph: AEP={aep}, Duration={dur}, TP={tp}, CSV={csv_read}")
 
         hydrographs = read_csv(
             filepath=csv_read,
@@ -303,9 +290,7 @@ def generate_finaldb(df: pd.DataFrame) -> pd.DataFrame:
     try:
         grouped = df.groupby(["TrimRC", "Location", "ThresholdFlow", "AEP"])
         for name, group in grouped:
-            median, Tcrit, Tpcrit, low, high = stats(
-                group, "Duration_Exceeding", "TP", "Duration"
-            )
+            median, Tcrit, Tpcrit, low, high = stats(group, "Duration_Exceeding", "TP", "Duration")
             if None in [median, Tcrit, Tpcrit, low, high]:
                 logger.warning(f"Incomplete stats for group {name}. Skipping.")
                 print(finaldb_records)
@@ -362,13 +347,11 @@ def main(do_plots: bool = False):
         do_plots (bool): Flag to indicate whether to generate plots. Currently ignored.
     """
     try:
-        working_dir = Path(__file__).resolve().parent
+        working_dir = Path(__file__).absolute().parent
         logger.info(f"Working directory set to {working_dir}")
 
         # Recursively search for PO CSV files
-        logger.info(
-            "Recursively searching for '**/*_PO.csv' files. This may take a while..."
-        )
+        logger.info("Recursively searching for '**/*_PO.csv' files. This may take a while...")
         file_list = list(working_dir.rglob("*_PO.csv"))
         logger.info(f"Found {len(file_list)} PO files.")
 
@@ -386,14 +369,8 @@ def main(do_plots: bool = False):
         with ProcessPoolExecutor(max_workers=max_workers) as executor:
             # Split file_list into chunks for each worker
             chunk_size = max(1, len(file_list) // max_workers)
-            file_chunks = [
-                file_list[i : i + chunk_size]
-                for i in range(0, len(file_list), chunk_size)
-            ]
-            futures = {
-                executor.submit(process_files, chunk, DURATION_SKIP_LIST): chunk
-                for chunk in file_chunks
-            }
+            file_chunks = [file_list[i : i + chunk_size] for i in range(0, len(file_list), chunk_size)]
+            futures = {executor.submit(process_files, chunk, DURATION_SKIP_LIST): chunk for chunk in file_chunks}
             for future in as_completed(futures):
                 result = future.result()
                 if result:
@@ -414,8 +391,7 @@ def main(do_plots: bool = False):
         hydro_data_list = []
         with ProcessPoolExecutor(max_workers=max_workers) as executor:
             hydro_futures = {
-                executor.submit(process_hydrographCSV, row): row
-                for row in files_df.to_dict(orient="records")
+                executor.submit(process_hydrographCSV, row): row for row in files_df.to_dict(orient="records")
             }
             for future in as_completed(hydro_futures):
                 result = future.result()

--- a/ryan-scripts/TUFLOW-python/run_tuflow_2025_07.py
+++ b/ryan-scripts/TUFLOW-python/run_tuflow_2025_07.py
@@ -547,7 +547,7 @@ def main() -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    script_dir: Path = Path(__file__).resolve().parent
+    script_dir: Path = Path(__file__).absolute().parent
     os.chdir(path=script_dir)
     logging.info(msg=f"Working dir: {script_dir}")
 

--- a/ryan-scripts/TUFLOW-python/run_tuflow_2025_09.py
+++ b/ryan-scripts/TUFLOW-python/run_tuflow_2025_09.py
@@ -959,7 +959,7 @@ def main() -> None:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    script_dir: Path = Path(__file__).resolve().parent
+    script_dir: Path = Path(__file__).absolute().parent
     os.chdir(path=script_dir)
     logging.info("Working dir: %s", script_dir)
 

--- a/ryan-scripts/TUFLOW-python/ss/TUFLOW_SimpleCulvert_v13.py
+++ b/ryan-scripts/TUFLOW-python/ss/TUFLOW_SimpleCulvert_v13.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 import os
 from glob import iglob
 import csv
@@ -17,17 +18,13 @@ import fiona
 
 
 def setup_logging():
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def make_file_list(searchString) -> list[str]:
     textString: str = r"**/*" + searchString
     print(f"Recursively searching for {textString} files - can take a while")
-    file_list: list[str] = [
-        f for f in iglob(pathname=textString, recursive=True) if os.path.isfile(path=f)
-    ]
+    file_list: list[str] = [f for f in iglob(pathname=textString, recursive=True) if os.path.isfile(path=f)]
     print(file_list)
     return file_list
 
@@ -147,9 +144,7 @@ def processCSV(file) -> DataFrame:
 
         # split the run code up by '_'
         dfData["internalName"] = internalName
-        for elem in enumerate(
-            iterable=internalName.replace("+", "_").split(sep="_"), start=1
-        ):
+        for elem in enumerate(iterable=internalName.replace("+", "_").split(sep="_"), start=1):
             dfData[f"R{elem[0]}"] = elem[1]
         dfData["path"] = file
         dfData["file"] = fileName
@@ -253,7 +248,7 @@ def export_to_excel(df, suffix) -> None:
 
 
 def main() -> None:
-    script_dir = os.path.dirname(os.path.realpath(__file__))
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     setup_logging()
 
@@ -316,7 +311,7 @@ def main() -> None:
 
 
 def main_old() -> None:
-    script_dir = os.path.dirname(os.path.realpath(__file__))
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     setup_logging()
     # '1d_V.csv'
@@ -358,9 +353,7 @@ def main_old() -> None:
 
     print(" --now 1dcc1")
     if ccafile_list == []:
-        print(
-            "ccafile_list is empty - skipping - this might be using GPKG which I haven't implemented yet"
-        )
+        print("ccafile_list is empty - skipping - this might be using GPKG which I haven't implemented yet")
     else:
         numFiles = calculate_pool_size(len(ccafile_list))
         with multiprocessing.Pool(numFiles) as p:
@@ -401,9 +394,7 @@ def main_old() -> None:
     print(df.dtypes)
     print("")
 
-    DateTimeString = (
-        datetime.now().strftime("%Y%m%d") + "-" + datetime.now().strftime("%H%M")
-    )
+    DateTimeString = datetime.now().strftime("%Y%m%d") + "-" + datetime.now().strftime("%H%M")
     export_name = f"{DateTimeString}_1d_data_max.xlsx"
     print(f"Exporting {export_name}")
     df.to_excel(export_name)

--- a/ryan-scripts/TUFLOW-python/ss/run_tuflow_2024_10.py
+++ b/ryan-scripts/TUFLOW-python/ss/run_tuflow_2024_10.py
@@ -414,7 +414,7 @@ def main() -> None:
         script_start_time = datetime.datetime.now()
         print(f"Script start time: {script_start_time.strftime('%Y-%m-%d %H:%M:%S')}")
 
-        script_dir = Path(__file__).resolve().parent
+        script_dir = Path(__file__).absolute().parent
         os.chdir(script_dir)
         print(f"Script directory: {script_dir}")
 

--- a/ryan-scripts/TUFLOW-python/ss/run_tuflow_September2024.py
+++ b/ryan-scripts/TUFLOW-python/ss/run_tuflow_September2024.py
@@ -1,4 +1,5 @@
 import datetime
+from pathlib import Path
 import subprocess
 import itertools
 import pprint
@@ -19,13 +20,9 @@ def get_parameters() -> dict[
     tcf: str = r".\runs\~s1~_17_~s2~_~e1~_~e2~_~s4~.tcf"
     tuflowexe: str = r"C:\TUFLOW\2023-03-AF\TUFLOW_iSP_w64.exe"
     batch_commands: str = " -b -pu0 "
-    computational_priority: str = (
-        "/NORMAL"  # /LOW /BELOWNORMAL /NORMAL /ABOVENORMAL /HIGH /REALTIME
-    )
+    computational_priority: str = "/NORMAL"  # /LOW /BELOWNORMAL /NORMAL /ABOVENORMAL /HIGH /REALTIME
     # run_simulations: bool = False    #True False #if you only want the args list
-    next_run_file: str | None = (
-        None  # "run_HBI_36.py" # Fine to leave this as None if you don't want to
-    )
+    next_run_file: str | None = None  # "run_HBI_36.py" # Fine to leave this as None if you don't want to
     # priority_order = ['e3 s5']  # Define priority: e.g. ['e3', 's2'] e3 is highest, then s2, etc.
 
     parameters: dict[str, list[str]] = {
@@ -52,9 +49,7 @@ def get_parameters() -> dict[
     }
 
     if "priority_order" in locals():  # make sure it exists
-        priority_order = clean_priority_order(
-            priority_order
-        )  # allows for list, string, mixed input
+        priority_order = clean_priority_order(priority_order)  # allows for list, string, mixed input
     # the first item is the last to be iterated over.
     # so all the others would happen first before changing priority one
     # will be sorted in alphabetical order for items not listed
@@ -76,10 +71,7 @@ def get_parameters() -> dict[
 
     parameters = filter_parameters(parameters, tcf)
     parameters: dict[str, list[str]] = split_strings_in_dict(parameters)
-    max_lengths: dict[str, int] = {
-        k: max(len(v) for v in values) if values else 0
-        for k, values in parameters.items()
-    }
+    max_lengths: dict[str, int] = {k: max(len(v) for v in values) if values else 0 for k, values in parameters.items()}
 
     # Check if batch is None, empty, or contains only spaces
     if not batch_commands.strip():
@@ -116,9 +108,7 @@ def get_parameters() -> dict[
     required_vars = ["tuflowexe", "tcf", "batch"]
     missing_vars = [var for var in required_vars if var not in config]
     if missing_vars:
-        raise ValueError(
-            f"Missing required configuration(s): {', '.join(missing_vars)}"
-        )
+        raise ValueError(f"Missing required configuration(s): {', '.join(missing_vars)}")
 
     return config
 
@@ -127,17 +117,13 @@ def run_at_end(script_path: str | None = None) -> None:
     # Use subprocess.run() to execute the script
     if script_path:
         try:
-            process = subprocess.Popen(
-                ["python", script_path], creationflags=subprocess.CREATE_NEW_CONSOLE
-            )
+            process = subprocess.Popen(["python", script_path], creationflags=subprocess.CREATE_NEW_CONSOLE)
             stdout, stderr = process.communicate()
 
             if process.returncode == 0:
                 print("Script executed successfully.")
             else:
-                print(
-                    f"An error occurred:\nSTDOUT: {stdout.decode()}\nSTDERR: {stderr.decode()}"
-                )
+                print(f"An error occurred:\nSTDOUT: {stdout.decode()}\nSTDERR: {stderr.decode()}")
         except Exception as e:
             print(f"An error occurred: {e}")
     else:
@@ -163,9 +149,7 @@ def split_strings(input: Union[str, list[str]]) -> list[str]:
     return split_list
 
 
-def split_strings_in_dict(
-    params_dict: dict[str, Union[str, list[str]]]
-) -> dict[str, list[str]]:
+def split_strings_in_dict(params_dict: dict[str, Union[str, list[str]]]) -> dict[str, list[str]]:
     for key, value in params_dict.items():
         # Use split_strings to handle both string and list of strings cases
         params_dict[key] = split_strings(value)
@@ -187,13 +171,9 @@ def split_strings_in_dict(
 #     return params_dict
 
 
-def filter_parameters(
-    parameters: dict[str, list[str]], tcf: str
-) -> dict[str, list[str]]:
+def filter_parameters(parameters: dict[str, list[str]], tcf: str) -> dict[str, list[str]]:
     # Exclude parameters with effectively empty values
-    non_empty_parameters: dict[str, list[str]] = {
-        k: v for k, v in parameters.items() if v and v[0].strip()
-    }
+    non_empty_parameters: dict[str, list[str]] = {k: v for k, v in parameters.items() if v and v[0].strip()}
     parameter_names: set[str] = set(non_empty_parameters.keys())
     tcf_parameters: set[str] = set(re.findall(r"~(\w{2})~", tcf))
 
@@ -206,9 +186,7 @@ def filter_parameters(
 
     if extra_parameters:
         print("")
-        print(
-            "Warning: TCF filename is missing these flags:", ", ".join(extra_parameters)
-        )
+        print("Warning: TCF filename is missing these flags:", ", ".join(extra_parameters))
 
     return non_empty_parameters
 
@@ -245,9 +223,7 @@ def run_command(args: list[str], index: int, total: int) -> None:
     if process.returncode == 0:
         print("\033[92mSimulation completed successfully.\033[0m")  # Green
     else:
-        print(
-            f"\033[91mSimulation failed with return code {process.returncode}.\033[0m"
-        )  # Red
+        print(f"\033[91mSimulation failed with return code {process.returncode}.\033[0m")  # Red
 
     # if process.returncode == 0:
     #     print("Simulation completed successfully.")
@@ -274,10 +250,7 @@ def generate_arg(
     args.extend(batch)
     args += [
         item
-        for sublist in (
-            [f"-{key}", f"{value.ljust(max_lengths[key])}"]
-            for key, value in zip(keys, combination)
-        )
+        for sublist in ([f"-{key}", f"{value.ljust(max_lengths[key])}"] for key, value in zip(keys, combination))
         for item in sublist
     ]
     args.append(tcf)
@@ -292,10 +265,7 @@ def generate_all_args(
     combinations,
     max_lengths: dict[str, int],
 ) -> list[list[str]]:
-    return [
-        generate_arg(tuflowexe, batch, tcf, keys, combination, max_lengths)
-        for combination in combinations
-    ]
+    return [generate_arg(tuflowexe, batch, tcf, keys, combination, max_lengths) for combination in combinations]
 
 
 def export_args(args_list: list[list[str]], base_filename: str) -> None:
@@ -312,13 +282,11 @@ def export_args(args_list: list[list[str]], base_filename: str) -> None:
 
 
 def main() -> None:
-    script_dir = os.path.dirname(os.path.realpath(__file__))
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     print(script_dir)
     print("")
-    params: dict[
-        str, str | list[str] | dict[str, list[str]] | dict[str, int] | None
-    ] = get_parameters()
+    params: dict[str, str | list[str] | dict[str, list[str]] | dict[str, int] | None] = get_parameters()
 
     tuflowexe: str = params["tuflowexe"]  # type: ignore
     batch: list[str] = params["batch"]  # type: ignore
@@ -336,23 +304,17 @@ def main() -> None:
         priority_order = params["priority_order"]
         sorted_keys = sorted(
             keys,
-            key=lambda x: (
-                priority_order.index(x) if x in priority_order else len(priority_order)
-            ),
+            key=lambda x: (priority_order.index(x) if x in priority_order else len(priority_order)),
         )
         # Step 3: Use sorted_keys for combinations
-        combinations = list(
-            itertools.product(*(parameters[key] for key in sorted_keys))
-        )
+        combinations = list(itertools.product(*(parameters[key] for key in sorted_keys)))
     else:
         # Fallback to original keys order if priority_order doesn't exist
         sorted_keys, values = zip(*sorted(parameters.items()))
         combinations = list(itertools.product(*values))
 
     # Generate all the command line arguments
-    args_list: list[list[str]] = generate_all_args(
-        tuflowexe, batch, tcf, sorted_keys, combinations, max_lengths
-    )
+    args_list: list[list[str]] = generate_all_args(tuflowexe, batch, tcf, sorted_keys, combinations, max_lengths)
 
     # Print all arguments before presenting the parameters
     print("All Generated Arguments:")
@@ -377,9 +339,7 @@ def main() -> None:
                 time.sleep(wait_time_after_run)
         run_at_end(script_path=next_run_file)
     else:
-        print(
-            f'TUFLOW runs exported to text file only - run_simulations: {params["run_simulations"]}'
-        )
+        print(f'TUFLOW runs exported to text file only - run_simulations: {params["run_simulations"]}')
         print()
     subprocess.call("pause", shell=True)  # wait for exit
 

--- a/ryan-scripts/fix-chatgpt-type-hints.py
+++ b/ryan-scripts/fix-chatgpt-type-hints.py
@@ -18,9 +18,7 @@ def fix_type_hints(file_path: Path) -> None:
                 bad_types: list[str] = ["List", "Dict", "Tuple", "Set"]
                 if any(bad_type in line for bad_type in bad_types):
                     found_bad_imports = True
-                    print(
-                        f"Bad import found: {file_path} (Line {line_number}): {line.strip()}"
-                    )
+                    print(f"Bad import found: {file_path} (Line {line_number}): {line.strip()}")
 
             original_line: str = line
             # Replace incorrect type hints using regex
@@ -41,7 +39,7 @@ def fix_type_hints(file_path: Path) -> None:
 
 def process_folders(folder_paths: list[Path]) -> None:
     """Process all Python files in multiple folders."""
-    script_path: Path = Path(__file__).resolve()  # Dynamically get the script's path
+    script_path: Path = Path(__file__).absolute()  # Dynamically get the script's path
     for folder_path in folder_paths:
         folder: Path = Path(folder_path).resolve()  # Resolve to absolute path
         if not folder.exists():

--- a/ryan-scripts/gdal-python/GDAL_Flood_Extent.py
+++ b/ryan-scripts/gdal-python/GDAL_Flood_Extent.py
@@ -14,7 +14,7 @@ def main():
     """
     try:
         # Determine the script directory
-        script_directory: Path = Path(__file__).resolve().parent
+        script_directory: Path = Path(__file__).absolute().parent
 
         # Optionally, override the script directory
         # Example:

--- a/ryan-scripts/gdal-python/build_VRT_v1.py
+++ b/ryan-scripts/gdal-python/build_VRT_v1.py
@@ -144,15 +144,11 @@ def find_tif_files(root_dir, extension, allowed_suffixes):
         for filename in filenames:
             if filename.lower().endswith(extension):
                 name_without_ext = os.path.splitext(filename)[0]
-                if any(
-                    name_without_ext.endswith(suffix) for suffix in allowed_suffixes
-                ):
+                if any(name_without_ext.endswith(suffix) for suffix in allowed_suffixes):
                     full_path = os.path.join(dirpath, filename)
                     tif_files.append(full_path)
                 else:
-                    logging.info(
-                        f"Skipping file (does not match allowed suffixes): {filename}"
-                    )
+                    logging.info(f"Skipping file (does not match allowed suffixes): {filename}")
     return tif_files
 
 
@@ -175,9 +171,7 @@ def extract_base_name(filename, group_remove_index):
     # Adjust for 1-based indexing
     index = group_remove_index - 1
     if index < 0 or index >= len(parts):
-        logging.warning(
-            f"Filename '{filename}' does not have field {group_remove_index}. Skipping."
-        )
+        logging.warning(f"Filename '{filename}' does not have field {group_remove_index}. Skipping.")
         return None
     # Remove the specified field
     del parts[index]
@@ -289,9 +283,7 @@ def create_vrt(vrt_path, input_files, gdalbuildvrt_path) -> None:
         logging.error(f"GDAL build VRT failed for '{vrt_path}': {e}")
         return
     except PermissionError:
-        logging.error(
-            f"Access denied when writing to '{file_list_path}' or creating VRT '{vrt_path}'."
-        )
+        logging.error(f"Access denied when writing to '{file_list_path}' or creating VRT '{vrt_path}'.")
         return
     except Exception as e:
         logging.error(f"Unexpected error during VRT creation for '{vrt_path}': {e}")
@@ -303,13 +295,9 @@ def create_vrt(vrt_path, input_files, gdalbuildvrt_path) -> None:
                 os.remove(file_list_path)
                 logging.info(f"Removed temporary file list: {file_list_path}")
             except PermissionError:
-                logging.warning(
-                    f"Access denied when trying to remove temporary file list: {file_list_path}"
-                )
+                logging.warning(f"Access denied when trying to remove temporary file list: {file_list_path}")
             except Exception as e:
-                logging.warning(
-                    f"Error removing temporary file list '{file_list_path}': {e}"
-                )
+                logging.warning(f"Error removing temporary file list '{file_list_path}': {e}")
 
 
 # ========================
@@ -348,16 +336,14 @@ def main():
     check_required_components(values)
 
     # Get the directory where the script is located and change to it
-    script_dir = Path(__file__).resolve().parent
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     logging.info(f"Changed working directory to: {script_dir}")
 
     logging.info(f"Searching for .tif files in: {script_dir}")
 
     # Step 1: Find all .tif files that end with allowed suffixes
-    tif_files = find_tif_files(
-        script_dir, values["file_extension"], values["allowed_suffixes"]
-    )
+    tif_files = find_tif_files(script_dir, values["file_extension"], values["allowed_suffixes"])
     logging.info(f"Found {len(tif_files)} .tif files matching allowed suffixes.")
 
     if not tif_files:
@@ -367,9 +353,7 @@ def main():
     # Step 2: Group files by base name after removing the specified field
     group_remove_index = values["group_remove_index"]
     groups = group_files_by_base(tif_files, group_remove_index)
-    logging.info(
-        f"Grouped into {len(groups)} sets based on removing field {group_remove_index}."
-    )
+    logging.info(f"Grouped into {len(groups)} sets based on removing field {group_remove_index}.")
 
     # Output all groups to a text file
     groups_output_path = os.path.join(script_dir, "groups.txt")

--- a/ryan-scripts/gdal-python/gdal_translate_TIF_ovr_v12.py
+++ b/ryan-scripts/gdal-python/gdal_translate_TIF_ovr_v12.py
@@ -409,6 +409,6 @@ def run_app() -> None:
 
 
 if __name__ == "__main__":
-    script_dir = Path(__file__).resolve().parent
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     run_app()

--- a/ryan-scripts/gdal-python/gdal_translate_TIF_ovr_v13.py
+++ b/ryan-scripts/gdal-python/gdal_translate_TIF_ovr_v13.py
@@ -14,7 +14,7 @@ from ryan_library.functions.gdal.gdal_environment import (
 
 
 def main() -> None:
-    script_dir: Path = Path(__file__).resolve().parent
+    script_dir: Path = Path(__file__).absolute().parent
     script_dir = Path(
         r"P:\BGER\PER\RP20181.366 HOPE DOWNS 4 EARLY TONNES - RTIO\7 DOCUMENT CONTROL\2 RECEIVED DATA\1 CLIENT\250220 - HD Pipeline Survey\DTM Surface XYZ"
     )
@@ -79,14 +79,10 @@ def get_processing_parameters() -> tuple[list[str], list[str], list[str], str, s
 
 
 def main_process() -> None:
-    items, commands, gdaladdo_commands, gdal_translate_path, gdaladdo_path = (
-        get_processing_parameters()
-    )
+    items, commands, gdaladdo_commands, gdal_translate_path, gdaladdo_path = get_processing_parameters()
     max_instances: int = os.cpu_count() or 1
 
-    tasks, skipped_files, max_lengths = prepare_tasks(
-        Path.cwd(), items, commands, gdaladdo_commands
-    )
+    tasks, skipped_files, max_lengths = prepare_tasks(Path.cwd(), items, commands, gdaladdo_commands)
 
     if not tasks:
         handle_no_tasks(skipped_files)
@@ -161,9 +157,7 @@ def run_gdal_commands_with_output(
                 raise Exception(f"gdal_translate failed for {task.out_file.name}")
 
         if success and task.process_ovr:
-            success = execute_gdaladdo(
-                gdaladdo_path, task.gdaladdo_commands, task.out_file, max_lengths
-            )
+            success = execute_gdaladdo(gdaladdo_path, task.gdaladdo_commands, task.out_file, max_lengths)
             if not success:
                 raise Exception(f"gdaladdo failed for {task.out_file.name}")
 
@@ -193,9 +187,7 @@ def execute_gdal_translate(
         + f" -> {out_file.name}"
     )
     print(translate_text)
-    command: list[str] = (
-        [gdal_translate_path] + commands + [str(source_file), str(out_file)]
-    )
+    command: list[str] = [gdal_translate_path] + commands + [str(source_file), str(out_file)]
     try:
         result: subprocess.CompletedProcess = subprocess.run(
             command,
@@ -216,9 +208,7 @@ def execute_gdaladdo(
     out_file: Path,
     max_lengths: dict[str, int],
 ) -> bool:
-    addo_text: str = f"Running gdaladdo: {out_file.name}".ljust(
-        max_lengths["max_filename_length"]
-    )
+    addo_text: str = f"Running gdaladdo: {out_file.name}".ljust(max_lengths["max_filename_length"])
     print(addo_text)
     command: list[str] = [gdaladdo_path] + gdaladdo_commands + ["-ro", str(out_file)]
     try:
@@ -262,12 +252,8 @@ def prepare_tasks(
             source_file: Path = file_path
             tif_file: Path = file_path.with_suffix(f".{output_format}")
             relative_path = file_path.relative_to(directory)
-            max_filename_length = max(
-                max_filename_length, len(file_path.name), len(tif_file.name)
-            )
-            max_relative_path_length = max(
-                max_relative_path_length, len(str(relative_path))
-            )
+            max_filename_length = max(max_filename_length, len(file_path.name), len(tif_file.name))
+            max_relative_path_length = max(max_relative_path_length, len(str(relative_path)))
             process_tif: bool = False
             process_ovr: bool = False
             source_mtime: float = source_file.stat().st_mtime

--- a/ryan-scripts/gdal-python/gdaladdo_tif_pyramids_v5.py
+++ b/ryan-scripts/gdal-python/gdaladdo_tif_pyramids_v5.py
@@ -299,6 +299,6 @@ def run_app() -> None:
 
 
 if __name__ == "__main__":
-    script_dir = Path(__file__).resolve().parent
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     run_app()

--- a/ryan-scripts/gdal-python/gdaladdo_tif_pyramids_v6.py
+++ b/ryan-scripts/gdal-python/gdaladdo_tif_pyramids_v6.py
@@ -299,6 +299,6 @@ def run_app() -> None:
 
 
 if __name__ == "__main__":
-    script_dir = Path(__file__).resolve().parent
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     run_app()

--- a/ryan-scripts/gdal-python/ss/gdal_translate_TIF_ovr_v11.py
+++ b/ryan-scripts/gdal-python/ss/gdal_translate_TIF_ovr_v11.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import subprocess
 import concurrent.futures
 from threading import Thread
@@ -335,6 +336,6 @@ def run_app() -> None:
 
 
 if __name__ == "__main__":
-    script_dir: str = os.path.dirname(os.path.realpath(__file__))
+    script_dir: str = Path(__file__).absolute().parent
     os.chdir(script_dir)
     run_app()

--- a/ryan-scripts/misc-python/EAS.py
+++ b/ryan-scripts/misc-python/EAS.py
@@ -312,7 +312,7 @@ def calculate_polygon_areas(poly1_df: pd.DataFrame, poly2_df: pd.DataFrame) -> t
 
 def main():
     # Determine the script's directory
-    script_dir = Path(__file__).parent.resolve()
+    script_dir = Path(__file__).absolute().parent
 
     # Generate a random stream profile
     profile_df = generate_random_profile()

--- a/ryan-scripts/misc-python/RFFE_Only_v3.py
+++ b/ryan-scripts/misc-python/RFFE_Only_v3.py
@@ -19,15 +19,13 @@ def main():
     Modify the `input_folder` and `output_folder` variables below to change directories.
     """
     # Define script directory
-    script_directory: Path = Path(__file__).resolve().parent
+    script_directory: Path = Path(__file__).absolute().parent
     print(f"📂 Script directory resolved to: {script_directory}")
 
     # Set input and output directories
     # By default, output_folder is the same as input_folder
     input_folder: Path = script_directory
-    output_folder: Path = (
-        input_folder  # Change this if you want a different output directory
-    )
+    output_folder: Path = input_folder  # Change this if you want a different output directory
 
     # Example to override output_folder by uncommenting the following line:
     # output_folder = Path(r"/path/to/custom/output/directory")
@@ -69,9 +67,7 @@ def main():
     for idx, row in ctchdata.iterrows():
         catchment_number = idx + 1
         catchment_name = row.get("Catchment", f"Catchment_{catchment_number}")
-        print(
-            f"🔄 Processing catchment {catchment_number}/{total_catchments}: {catchment_name}"
-        )
+        print(f"🔄 Processing catchment {catchment_number}/{total_catchments}: {catchment_name}")
         rffe_results_df, all_catchments_df, error_info = process_catchment(
             lato=row.get("OutletY"),
             lono=row.get("OutletX"),
@@ -96,20 +92,14 @@ def main():
             print(f"⚠️ Catchment {catchment_name} failed with error: {error_info}")
         else:
             if not rffe_results_df.empty:
-                rffes_results = pd.concat(
-                    [rffes_results, rffe_results_df], ignore_index=True
-                )
+                rffes_results = pd.concat([rffes_results, rffe_results_df], ignore_index=True)
             else:
                 print(f"⚠️ No 'results' data returned for catchment: {catchment_name}")
 
             if not all_catchments_df.empty:
-                all_catchments_results = pd.concat(
-                    [all_catchments_results, all_catchments_df], ignore_index=True
-                )
+                all_catchments_results = pd.concat([all_catchments_results, all_catchments_df], ignore_index=True)
             else:
-                print(
-                    f"⚠️ No 'allCatchmentResults' data returned for catchment: {catchment_name}"
-                )
+                print(f"⚠️ No 'allCatchmentResults' data returned for catchment: {catchment_name}")
 
     # Define the output CSV paths
     output_results_csv_path = output_folder / "rffe_results.csv"
@@ -124,9 +114,7 @@ def main():
         print(f"❌ Failed to save 'results' CSV: {e}")
         sys.exit(1)
 
-    print(
-        f"💾 Saving aggregated 'allCatchmentResults' data to: {output_all_catchments_csv_path}"
-    )
+    print(f"💾 Saving aggregated 'allCatchmentResults' data to: {output_all_catchments_csv_path}")
     try:
         all_catchments_results.to_csv(output_all_catchments_csv_path, index=False)
         print("✅ 'allCatchmentResults' data saved successfully.")
@@ -244,9 +232,7 @@ def clean_rffe(rffe_results: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     for script in scripts:
         if script.string:
             if "results =" in script.string:
-                match = re.search(
-                    r"results\s*=\s*(\[\{.*?\}\]);", script.string, re.DOTALL
-                )
+                match = re.search(r"results\s*=\s*(\[\{.*?\}\]);", script.string, re.DOTALL)
                 if match:
                     results_str = match.group(1)
             if "allCatchmentResults =" in script.string:
@@ -295,9 +281,7 @@ def clean_rffe(rffe_results: str) -> tuple[pd.DataFrame, pd.DataFrame]:
     return df_results, df_all_catchments
 
 
-def save_results_to_files(
-    catchment: str, folder_path: Path, rffe_response: requests.Response
-):
+def save_results_to_files(catchment: str, folder_path: Path, rffe_response: requests.Response):
     """
     Saves the raw RFFE response text to a file named '{catchment}_rffe.txt' in the specified folder.
 
@@ -366,9 +350,7 @@ def process_catchment(
 
     except Exception as e:
         error_message = str(e)
-        print(
-            f"❌ An error occurred while processing catchment {name}: {error_message}"
-        )
+        print(f"❌ An error occurred while processing catchment {name}: {error_message}")
         return pd.DataFrame(), pd.DataFrame(), error_message
 
 

--- a/ryan-scripts/misc-python/combine_ifds_v2.py
+++ b/ryan-scripts/misc-python/combine_ifds_v2.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pandas as pd
 import re
 
@@ -171,25 +172,15 @@ def extract_data_from_csv(file_path: str, lookup_df: pd.DataFrame) -> pd.DataFra
         print(f"Data reshaped successfully. Long DataFrame shape: {long_df.shape}")
 
         # Process grid_lat and grid_long
-        long_df["grid_lat"] = long_df["grid_lat"].apply(
-            lambda x: process_coordinate(x, "lat")
-        )
-        long_df["grid_long"] = long_df["grid_long"].apply(
-            lambda x: process_coordinate(x, "long")
-        )
+        long_df["grid_lat"] = long_df["grid_lat"].apply(lambda x: process_coordinate(x, "lat"))
+        long_df["grid_long"] = long_df["grid_long"].apply(lambda x: process_coordinate(x, "long"))
 
         # Process req_lat and req_long
-        long_df["req_lat"] = long_df["req_lat"].apply(
-            lambda x: process_coordinate(x, "lat")
-        )
-        long_df["req_long"] = long_df["req_long"].apply(
-            lambda x: process_coordinate(x, "long")
-        )
+        long_df["req_lat"] = long_df["req_lat"].apply(lambda x: process_coordinate(x, "lat"))
+        long_df["req_long"] = long_df["req_long"].apply(lambda x: process_coordinate(x, "long"))
 
         # Convert 'Duration in min' to integer
-        long_df["Duration in min"] = pd.to_numeric(
-            long_df["Duration in min"], errors="coerce"
-        ).astype("Int64")
+        long_df["Duration in min"] = pd.to_numeric(long_df["Duration in min"], errors="coerce").astype("Int64")
 
         # Merge with lookup_df to add additional AEP details
         merged_df = long_df.merge(
@@ -295,7 +286,7 @@ def find_and_process_files(script_dir: str, lookup_df: pd.DataFrame) -> pd.DataF
 
 
 def main() -> None:
-    script_dir = os.path.dirname(os.path.abspath(__file__))
+    script_dir = Path(__file__).absolute().parent
     print(f"Script directory: {script_dir}")
 
     # Step 1: Find and process CSV files
@@ -304,19 +295,15 @@ def main() -> None:
 
     if not all_data_long.empty:
         # Step 2: Export the complete long data to CSV
-        all_data_csv_path = os.path.join(
-            script_dir, "all_location_data_with_AEP_lookup.csv"
-        )
+        all_data_csv_path = os.path.join(script_dir, "all_location_data_with_AEP_lookup.csv")
         all_data_long.to_csv(all_data_csv_path, index=False)
-        print(
-            f"Step 2: Exported all location data (long format) with AEP lookup to '{all_data_csv_path}'."
-        )
+        print(f"Step 2: Exported all location data (long format) with AEP lookup to '{all_data_csv_path}'.")
     else:
         print("No valid data to export.")
 
 
 if __name__ == "__main__":
-    working_dir = os.path.dirname(os.path.realpath(__file__))
+    working_dir = Path(__file__).absolute().parent
     os.chdir(working_dir)
     print(f"Changed working directory to: {working_dir}")
 

--- a/ryan-scripts/misc-python/ss/RFFE_batch.py
+++ b/ryan-scripts/misc-python/ss/RFFE_batch.py
@@ -4,7 +4,7 @@ from loguru import logger
 from pathlib import Path
 import pandas as pd
 
-script_directory: Path = Path(__file__).resolve().parent
+script_directory: Path = Path(__file__).absolute().parent
 script_directory = Path(r"Q:\BGER\PER\RPRT\ryan-tools\tests\test_data")
 
 
@@ -19,9 +19,7 @@ INPUT_CATCHMENTS_FILENAME = "input_catchments.csv"
 OUTPUT_RFFE_FILENAME = "rffe.csv"
 
 
-def fetch_rffe(
-    lono: float, lato: float, lonc: float, latc: float, area: float
-) -> requests.Response:
+def fetch_rffe(lono: float, lato: float, lonc: float, latc: float, area: float) -> requests.Response:
     """
     Fetch RFFE data from the specified URL.
 
@@ -68,12 +66,7 @@ def clean_rffe(rffe_results: str) -> pd.DataFrame:
         # Extract the JSON-like part from the response
         results_str = rffe_results.split("results=[{")[1].split("}]")[0]
         # Replace '},{' with '};{' to split records
-        records = (
-            results_str.replace("},{", "};{")
-            .replace("{", "")
-            .replace("}", "")
-            .split(";")
-        )
+        records = results_str.replace("},{", "};{").replace("{", "").replace("}", "").split(";")
 
         # Parse each record into a dictionary
         data = []
@@ -92,9 +85,7 @@ def clean_rffe(rffe_results: str) -> pd.DataFrame:
         raise
 
 
-def save_results_to_file(
-    catchment: str, folder_path: str, rffe_response: requests.Response
-) -> None:
+def save_results_to_file(catchment: str, folder_path: str, rffe_response: requests.Response) -> None:
     """
     Save the RFFE response text to a file.
 

--- a/ryan-scripts/python-not-polished/hydrograph_extract_rorb_csv-opt2_132.py
+++ b/ryan-scripts/python-not-polished/hydrograph_extract_rorb_csv-opt2_132.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pandas as pd
 from datetime import datetime
 import re
@@ -33,9 +34,7 @@ def extract_metadata_from_filename(file_name):
         tp = f"tp{match.group('tp')}"
 
         # Print the extracted metadata
-        print(
-            f"Extracted Metadata - Crossing Name: {crossing_name}, AEP: {aep}, Duration: {duration}, TP: {tp}"
-        )
+        print(f"Extracted Metadata - Crossing Name: {crossing_name}, AEP: {aep}, Duration: {duration}, TP: {tp}")
 
         return crossing_name, aep, duration, tp
     else:
@@ -58,9 +57,7 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
     """
     # Precompile regex patterns for efficiency
     regex_patterns = {
-        (aep, tp): re.compile(
-            rf"{re.escape(aep)}_du12hour{re.escape(tp)}\b", re.IGNORECASE
-        )
+        (aep, tp): re.compile(rf"{re.escape(aep)}_du12hour{re.escape(tp)}\b", re.IGNORECASE)
         for aep, tp in selected_combinations
     }
 
@@ -107,9 +104,7 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
         df.columns = [col.strip() for col in df.columns]
 
         # Identify hydrograph columns (excluding 'Inc' and 'Time (hrs)')
-        hydrograph_columns = [
-            col for col in df.columns if col not in ["Inc", "Time (hrs)"]
-        ]
+        hydrograph_columns = [col for col in df.columns if col not in ["Inc", "Time (hrs)"]]
 
         if len(hydrograph_columns) == 0:
             print(f"No hydrograph columns found in {file_name}. Skipping.")
@@ -130,24 +125,18 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
                 print(
                     "Please specify the desired hydrograph by setting the 'selected_hydrograph' variable in the script."
                 )
-                print(
-                    "Example: selected_hydrograph = 'Calculated hydrograph: Outlet'\n"
-                )
+                print("Example: selected_hydrograph = 'Calculated hydrograph: Outlet'\n")
                 sys.exit(1)  # Exit the script with an error code
 
             elif selected_hydrograph not in hydrograph_columns:
-                print(
-                    f"\nError: The specified hydrograph '{selected_hydrograph}' is not found in {file_name}."
-                )
+                print(f"\nError: The specified hydrograph '{selected_hydrograph}' is not found in {file_name}.")
                 print(
                     "Please update the 'selected_hydrograph' variable with a valid hydrograph name from the list above.\n"
                 )
                 sys.exit(1)
 
             else:
-                selected_column = (
-                    selected_hydrograph  # Use the user-specified hydrograph
-                )
+                selected_column = selected_hydrograph  # Use the user-specified hydrograph
 
         # Extract relevant data
         try:
@@ -172,9 +161,7 @@ def import_data(script_directory, selected_combinations, selected_hydrograph):
         # Extract metadata from filename
         crossing_name, aep, duration, tp = extract_metadata_from_filename(file_name)
         if not all([crossing_name, aep, duration, tp]):
-            print(
-                f"Warning: Unable to extract metadata from {file_name}. Setting as 'Unknown'."
-            )
+            print(f"Warning: Unable to extract metadata from {file_name}. Setting as 'Unknown'.")
             crossing_name = crossing_name or "Unknown"
             aep = aep or "Unknown_AEP"
             duration = duration or "Unknown_Duration"
@@ -237,9 +224,7 @@ def create_plot(combined_df, aep_mapping, crossing_name, script_directory):
         # Sort AEPs based on percentage for ordered legend
         sorted_aeps = sorted(
             aep_mapping.keys(),
-            key=lambda x: (
-                int(re.search(r"\d+", x).group()) if re.search(r"\d+", x) else 0
-            ),
+            key=lambda x: (int(re.search(r"\d+", x).group()) if re.search(r"\d+", x) else 0),
         )
 
         for aep in sorted_aeps:
@@ -299,7 +284,7 @@ def create_plot(combined_df, aep_mapping, crossing_name, script_directory):
 
 def main():
     # Get the directory where the script is located
-    script_directory = os.path.dirname(os.path.abspath(__file__))
+    script_directory = Path(__file__).absolute().parent
 
     # Define specific combinations of AEP and TP to process
     selected_combinations = [
@@ -312,9 +297,7 @@ def main():
     ]
 
     # Import and aggregate data
-    combined_df, aep_mapping, crossing_name = import_data(
-        script_directory, selected_combinations, selected_hydrograph
-    )
+    combined_df, aep_mapping, crossing_name = import_data(script_directory, selected_combinations, selected_hydrograph)
 
     # Save combined data to a single-sheet Excel file
     try:
@@ -326,9 +309,7 @@ def main():
         output_file_path = os.path.join(script_directory, output_file_name)
 
         # Save to Excel with a single sheet
-        combined_df.to_excel(
-            output_file_path, index=False, sheet_name="Hydrograph Data"
-        )
+        combined_df.to_excel(output_file_path, index=False, sheet_name="Hydrograph Data")
         print(f"Combined hydrograph data saved to: {output_file_path}")
     except Exception as e:
         print(f"Error saving combined Excel file: {e}")

--- a/ryan_library/scripts/tuflow/tuflow_results_styling.py
+++ b/ryan_library/scripts/tuflow/tuflow_results_styling.py
@@ -24,7 +24,7 @@ class TUFLOWResultsStyler:
         """Initializes the TUFLOWResultsStyler with default styles path and user overrides."""
         # __file__ resolves to ryan_library/scripts/tuflow/tuflow_results_styling.py
         # We need the repository root to locate QML files under QGIS-Styles/TUFLOW
-        self.default_styles_path: Path = Path(__file__).resolve().parents[3] / "QGIS-Styles" / "TUFLOW"
+        self.default_styles_path: Path = Path(__file__).absolute().parents[3] / "QGIS-Styles" / "TUFLOW"
         logger.debug(self.default_styles_path)
         self.user_qml_overrides: dict[str, str] = user_qml_overrides or {}
         self.mappings: dict[str, MappingEntry] = self.get_file_mappings()

--- a/tests/classes/test_pomm_processor.py
+++ b/tests/classes/test_pomm_processor.py
@@ -4,7 +4,7 @@ import pandas as pd
 from ryan_library.processors.tuflow.POMMProcessor import POMMProcessor
 from ryan_library.classes.tuflow_string_classes import TuflowStringParser
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "test_data" / "tuflow"
+DATA_DIR = Path(__file__).absolute().parent.parent / "test_data" / "tuflow"
 
 with open(DATA_DIR / "pomm_run_codes.json", "r", encoding="utf-8") as fp:
     RUN_CODES = json.load(fp)
@@ -27,9 +27,7 @@ def test_tuflow_string_parser_examples():
         parser = TuflowStringParser(file_path)
         assert parser.run_code_parts == expected["run_code_parts"]
         assert (parser.aep.text_repr if parser.aep else None) == expected["aep"]
-        assert (parser.duration.text_repr if parser.duration else None) == expected[
-            "duration"
-        ]
+        assert (parser.duration.text_repr if parser.duration else None) == expected["duration"]
         assert (parser.tp.text_repr if parser.tp else None) == expected["tp"]
         assert parser.trim_run_code == expected["trim_run_code"]
 

--- a/tests/classes/test_tuflow_string_classes.py
+++ b/tests/classes/test_tuflow_string_classes.py
@@ -7,7 +7,7 @@ from ryan_library.classes.tuflow_string_classes import (
     RunCodeComponent,
 )
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "test_data" / "tuflow"
+DATA_DIR = Path(__file__).absolute().parent.parent / "test_data" / "tuflow"
 
 
 def locate_file(name: str) -> Path:
@@ -35,10 +35,7 @@ def suffixes():
     Load the real suffixes.json for testing.
     """
     with open(
-        Path(__file__).parent.parent.parent
-        / "ryan_library"
-        / "classes"
-        / "suffixes.json",
+        Path(__file__).parent.parent.parent / "ryan_library" / "classes" / "suffixes.json",
         "r",
         encoding="utf-8",
     ) as f:
@@ -63,79 +60,54 @@ def test_file_name_parsing(run_code_examples):
 
         assert parser.file_name == file_name, f"File name mismatch for {file_name}"
         if "data_type" in expected:
-            assert (
-                parser.data_type == expected["data_type"]
-            ), f"Data type mismatch for {file_name}"
+            assert parser.data_type == expected["data_type"], f"Data type mismatch for {file_name}"
         if "raw_run_code" in expected:
-            assert (
-                parser.raw_run_code == expected["raw_run_code"]
-            ), f"Raw run code mismatch for {file_name}"
+            assert parser.raw_run_code == expected["raw_run_code"], f"Raw run code mismatch for {file_name}"
         if "clean_run_code" in expected:
-            assert (
-                parser.clean_run_code == expected["clean_run_code"]
-            ), f"Clean run code mismatch for {file_name}"
-        assert parser.run_code_parts == expected.get(
-            "run_code_parts"
-        ), f"Run code parts mismatch for {file_name}"
+            assert parser.clean_run_code == expected["clean_run_code"], f"Clean run code mismatch for {file_name}"
+        assert parser.run_code_parts == expected.get("run_code_parts"), f"Run code parts mismatch for {file_name}"
 
         # Test RunCodeComponents
         if expected.get("tp") is not None:
             assert parser.tp is not None, f"TP component missing for {file_name}"
             if isinstance(expected["tp"], dict):
-                assert (
-                    parser.tp.text_repr == expected["tp"]["text_repr"]
-                ), f"TP text_repr mismatch for {file_name}"
+                assert parser.tp.text_repr == expected["tp"]["text_repr"], f"TP text_repr mismatch for {file_name}"
                 assert (
                     parser.tp.numeric_value == expected["tp"]["numeric_value"]
                 ), f"TP numeric_value mismatch for {file_name}"
             else:
-                assert (
-                    parser.tp.text_repr == expected["tp"]
-                ), f"TP value mismatch for {file_name}"
+                assert parser.tp.text_repr == expected["tp"], f"TP value mismatch for {file_name}"
         elif "tp" in expected:
             assert parser.tp is None, f"Unexpected TP component for {file_name}"
 
         if expected.get("duration") is not None:
-            assert (
-                parser.duration is not None
-            ), f"Duration component missing for {file_name}"
+            assert parser.duration is not None, f"Duration component missing for {file_name}"
             if isinstance(expected["duration"], dict):
                 assert (
                     parser.duration.text_repr == expected["duration"]["text_repr"]
                 ), f"Duration text_repr mismatch for {file_name}"
                 assert (
-                    parser.duration.numeric_value
-                    == expected["duration"]["numeric_value"]
+                    parser.duration.numeric_value == expected["duration"]["numeric_value"]
                 ), f"Duration numeric_value mismatch for {file_name}"
             else:
-                assert (
-                    parser.duration.text_repr == expected["duration"]
-                ), f"Duration value mismatch for {file_name}"
+                assert parser.duration.text_repr == expected["duration"], f"Duration value mismatch for {file_name}"
         elif "duration" in expected:
-            assert (
-                parser.duration is None
-            ), f"Unexpected Duration component for {file_name}"
+            assert parser.duration is None, f"Unexpected Duration component for {file_name}"
 
         if expected.get("aep") is not None:
             assert parser.aep is not None, f"AEP component missing for {file_name}"
             if isinstance(expected["aep"], dict):
-                assert (
-                    parser.aep.text_repr == expected["aep"]["text_repr"]
-                ), f"AEP text_repr mismatch for {file_name}"
+                assert parser.aep.text_repr == expected["aep"]["text_repr"], f"AEP text_repr mismatch for {file_name}"
                 assert (
                     parser.aep.numeric_value == expected["aep"]["numeric_value"]
                 ), f"AEP numeric_value mismatch for {file_name}"
             else:
-                assert (
-                    parser.aep.text_repr == expected["aep"]
-                ), f"AEP value mismatch for {file_name}"
+                assert parser.aep.text_repr == expected["aep"], f"AEP value mismatch for {file_name}"
         elif "aep" in expected:
             assert parser.aep is None, f"Unexpected AEP component for {file_name}"
 
         # Test trimmed run code
-        assert parser.trim_run_code == expected.get(
-            "trim_run_code"
-        ), f"Trimmed run code mismatch for {file_name}"
+        assert parser.trim_run_code == expected.get("trim_run_code"), f"Trimmed run code mismatch for {file_name}"
 
 
 def test_run_code_component():
@@ -168,9 +140,7 @@ def test_trim_runcode_function():
     tp = "TP12"
     expected = "R01_R02"
     result = trim_runcode(run_code, aep, duration, tp)
-    assert (
-        result == expected
-    ), f"Trim run code failed: expected {expected}, got {result}"
+    assert result == expected, f"Trim run code failed: expected {expected}, got {result}"
 
     # Test case 2: Some components missing
     run_code = "R01_TP12_AEP2.0"
@@ -179,9 +149,7 @@ def test_trim_runcode_function():
     tp = "TP12"
     expected = "R01"
     result = trim_runcode(run_code, aep, duration, tp)
-    assert (
-        result == expected
-    ), f"Trim run code failed: expected {expected}, got {result}"
+    assert result == expected, f"Trim run code failed: expected {expected}, got {result}"
 
     # Test case 3: No components to remove
     run_code = "R01_R02"
@@ -190,9 +158,7 @@ def test_trim_runcode_function():
     tp = None
     expected = "R01_R02"
     result = trim_runcode(run_code, aep, duration, tp)
-    assert (
-        result == expected
-    ), f"Trim run code failed: expected {expected}, got {result}"
+    assert result == expected, f"Trim run code failed: expected {expected}, got {result}"
 
     # Test case 4: Run code with different delimiters
     run_code = "R01+TP12+Duration300+AEP1.5"
@@ -201,6 +167,4 @@ def test_trim_runcode_function():
     tp = "TP12"
     expected = "R01"
     result = trim_runcode(run_code, aep, duration, tp)
-    assert (
-        result == expected
-    ), f"Trim run code failed with delimiters: expected {expected}, got {result}"
+    assert result == expected, f"Trim run code failed with delimiters: expected {expected}, got {result}"

--- a/tests/functions/test_pomm_peak_report.py
+++ b/tests/functions/test_pomm_peak_report.py
@@ -5,7 +5,7 @@ import sys
 import pandas as pd  # type: ignore
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).absolute().parents[2]))
 
 from ryan_library.scripts.pomm_utils import (
     aggregated_from_paths,
@@ -15,7 +15,7 @@ from ryan_library.scripts.pomm_utils import (
 from ryan_library.scripts.pomm_max_items import run_median_peak_report
 
 
-DATA_DIR = Path(__file__).resolve().parent.parent / "test_data" / "tuflow" / "tutorials"
+DATA_DIR = Path(__file__).absolute().parent.parent / "test_data" / "tuflow" / "tutorials"
 
 
 def test_aggregated_from_paths_module01() -> None:

--- a/tests/scripts/test_pomm_peak_report.py
+++ b/tests/scripts/test_pomm_peak_report.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pandas import DataFrame
 
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).absolute().parents[2]))
 
 from ryan_library.scripts.pomm_utils import (
     aggregated_from_paths,
@@ -14,7 +14,7 @@ from ryan_library.scripts.pomm_utils import (
 from ryan_library.scripts.pomm_max_items import run_median_peak_report
 
 
-DATA_DIR: Path = Path(__file__).resolve().parent.parent / "test_data" / "tuflow" / "tutorials"
+DATA_DIR: Path = Path(__file__).absolute().parent.parent / "test_data" / "tuflow" / "tutorials"
 
 
 def test_aggregated_from_paths_module01() -> None:

--- a/tests/test_data/tuflow/tutorials/Module_11/results/plot/csv/TUFLOW_SimpleCulvert_v13.py
+++ b/tests/test_data/tuflow/tutorials/Module_11/results/plot/csv/TUFLOW_SimpleCulvert_v13.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 import os
 from glob import iglob
 import csv
@@ -17,17 +18,13 @@ import fiona
 
 
 def setup_logging():
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
-    )
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def make_file_list(searchString) -> list[str]:
     textString: str = r"**/*" + searchString
     print(f"Recursively searching for {textString} files - can take a while")
-    file_list: list[str] = [
-        f for f in iglob(pathname=textString, recursive=True) if os.path.isfile(path=f)
-    ]
+    file_list: list[str] = [f for f in iglob(pathname=textString, recursive=True) if os.path.isfile(path=f)]
     print(file_list)
     return file_list
 
@@ -147,9 +144,7 @@ def processCSV(file) -> DataFrame:
 
         # split the run code up by '_'
         dfData["internalName"] = internalName
-        for elem in enumerate(
-            iterable=internalName.replace("+", "_").split(sep="_"), start=1
-        ):
+        for elem in enumerate(iterable=internalName.replace("+", "_").split(sep="_"), start=1):
             dfData[f"R{elem[0]}"] = elem[1]
         dfData["path"] = file
         dfData["file"] = fileName
@@ -253,7 +248,7 @@ def export_to_excel(df, suffix) -> None:
 
 
 def main() -> None:
-    script_dir = os.path.dirname(os.path.realpath(__file__))
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     setup_logging()
 
@@ -316,7 +311,7 @@ def main() -> None:
 
 
 def main_old() -> None:
-    script_dir = os.path.dirname(os.path.realpath(__file__))
+    script_dir = Path(__file__).absolute().parent
     os.chdir(script_dir)
     setup_logging()
     # '1d_V.csv'
@@ -358,9 +353,7 @@ def main_old() -> None:
 
     print(" --now 1dcc1")
     if ccafile_list == []:
-        print(
-            "ccafile_list is empty - skipping - this might be using GPKG which I haven't implemented yet"
-        )
+        print("ccafile_list is empty - skipping - this might be using GPKG which I haven't implemented yet")
     else:
         numFiles = calculate_pool_size(len(ccafile_list))
         with multiprocessing.Pool(numFiles) as p:
@@ -401,9 +394,7 @@ def main_old() -> None:
     print(df.dtypes)
     print("")
 
-    DateTimeString = (
-        datetime.now().strftime("%Y%m%d") + "-" + datetime.now().strftime("%H%M")
-    )
+    DateTimeString = datetime.now().strftime("%Y%m%d") + "-" + datetime.now().strftime("%H%M")
     export_name = f"{DateTimeString}_1d_data_max.xlsx"
     print(f"Exporting {export_name}")
     df.to_excel(export_name)

--- a/tests/test_data/tuflow/tutorials/TUFLOW_Culvert_Merge.py
+++ b/tests/test_data/tuflow/tutorials/TUFLOW_Culvert_Merge.py
@@ -13,7 +13,7 @@ def main():
 
     try:
         # Determine the script directory
-        script_directory: Path = Path(__file__).resolve().parent
+        script_directory: Path = Path(__file__).absolute().parent
         script_directory = Path(
             # r"Q:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials"
             r"E:\Library\Automation\ryan-tools\tests\test_data\tuflow\tutorials"


### PR DESCRIPTION
## Summary
- replace `Path(__file__).resolve()` and similar `os.path` calls with `Path(__file__).absolute()` in scripts and tests
- ensure script directories are determined without using `resolve` to avoid Windows `PAUSE` issues

## Testing
- `python -m mypy ryan-scripts/TUFLOW-python/in-progress/closure_tuflow_1D_v8a.py ryan-scripts/RORB-python/hydrograph_extract_rorb_csv.py` *(and other modified files; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a4368f10832ead3ab860e733cb53