### PR TITLE
[processors] Add stub TUFLOW H/V processors

### DIFF
--- a/ryan_library/processors/tuflow/HProcessor.py
+++ b/ryan_library/processors/tuflow/HProcessor.py
@@ -1,0 +1,24 @@
+"""Placeholder processor for TUFLOW H timeseries data.
+
+This stub will be implemented once the Q-processor path is stable so the shared
+infrastructure can be reused confidently.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base_processor import BaseProcessor
+
+
+class HProcessor(BaseProcessor):
+    """Stub processor for `_1d_H.csv` files until the Q-processor path is stable."""
+
+    def process(self) -> pd.DataFrame:
+        """Raise ``NotImplementedError`` until H processing is available.
+
+        TODO: Implement HProcessor once the Q-processor path is stable.
+        """
+        raise NotImplementedError(
+            "HProcessor is not implemented. It will be completed once the Q-processor path is stable."
+        )

--- a/ryan_library/processors/tuflow/VProcessor.py
+++ b/ryan_library/processors/tuflow/VProcessor.py
@@ -1,0 +1,24 @@
+"""Placeholder processor for TUFLOW V timeseries data.
+
+This stub will be implemented once the Q-processor path is stable so the shared
+infrastructure can be reused confidently.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from .base_processor import BaseProcessor
+
+
+class VProcessor(BaseProcessor):
+    """Stub processor for `_1d_V.csv` files until the Q-processor path is stable."""
+
+    def process(self) -> pd.DataFrame:
+        """Raise ``NotImplementedError`` until V processing is available.
+
+        TODO: Implement VProcessor once the Q-processor path is stable.
+        """
+        raise NotImplementedError(
+            "VProcessor is not implemented. It will be completed once the Q-processor path is stable."
+        )


### PR DESCRIPTION
## Summary
- add placeholder HProcessor and VProcessor modules that raise NotImplementedError
- document that the implementations will land once the Q-processor path is stable

## Testing
- `python - <<'PY'
from ryan_library.processors.tuflow.base_processor import BaseProcessor

for name in ("HProcessor", "VProcessor"):
    cls = BaseProcessor.get_processor_class(name)
    print(name, cls)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c8b2bce60c832eb8cc60643ae4bd26