### PR TITLE
[core] Drive POMM processing from config

### DIFF
--- a/ryan_library/classes/tuflow_results_validation_and_datatypes.json
+++ b/ryan_library/classes/tuflow_results_validation_and_datatypes.json
@@ -15,7 +15,24 @@
       "SignedAbsMax": "float"
     },
     "processingParts": {
-      "dataformat": "POMM"
+      "dataformat": "POMM",
+      "_note": "columns_to_use keys reflect the header row after transposing the raw POMM layout.",
+      "expected_in_header": [
+        "Location",
+        "Time",
+        "Maximum (Extracted from Time Series)",
+        "Time of Maximum",
+        "Minimum (Extracted From Time Series)",
+        "Time of Minimum"
+      ],
+      "columns_to_use": {
+        "Location": "string",
+        "Time": "string",
+        "Maximum (Extracted from Time Series)": "float",
+        "Time of Maximum": "float",
+        "Minimum (Extracted From Time Series)": "float",
+        "Time of Minimum": "float"
+      }
     }
   },
   "Cmx": {

--- a/ryan_library/processors/tuflow/base_processor.py
+++ b/ryan_library/processors/tuflow/base_processor.py
@@ -148,14 +148,17 @@ class BaseProcessor(ABC):
             f"{self.file_name}: Loaded processingParts - dataformat: {self.dataformat}, skip_columns: {self.skip_columns}"
         )
 
-        # Depending on dataformat, load columns_to_use or expected_in_header
-        if self.dataformat in ["Maximums", "ccA"]:
+        handled_formats: set[str] = {"Maximums", "ccA", "Timeseries", "POMM"}
+
+        if self.dataformat in {"Maximums", "ccA", "POMM"}:
             self.columns_to_use = processing_parts.columns_to_use
             logger.debug(f"{self.file_name}: Loaded columns_to_use: {self.columns_to_use}")
-        elif self.dataformat == "Timeseries":
+
+        if self.dataformat in {"Timeseries", "POMM"}:
             self.expected_in_header = processing_parts.expected_in_header
             logger.debug(f"{self.file_name}: Loaded expected_in_header: {self.expected_in_header}")
-        else:
+
+        if self.dataformat not in handled_formats:
             logger.warning(f"{self.file_name}: Unknown dataformat '{self.dataformat}'.")
 
     @abstractmethod


### PR DESCRIPTION
## Summary
- keep the POMM header expectations in the shared configuration while documenting that the transposed columns drive validation
- have the base processor load those configured headers without introducing a rename mapping attribute
- localise the column renaming inside `POMMProcessor` while continuing to apply configured dtype rules

## Testing
- PYTHONPATH=. pytest tests/classes/test_pomm_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68c8b27b99ac832e90a86411c1058bec