### PR TITLE
[tuflow] Preserve melted Q identifier column names

### DIFF
--- a/ryan_library/processors/tuflow/ChanProcessor.py
+++ b/ryan_library/processors/tuflow/ChanProcessor.py
@@ -1,8 +1,8 @@
 # ryan_library/processors/tuflow/ChanProcessor.py
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 from loguru import logger
-from .base_processor import BaseProcessor
+from .base_processor import BaseProcessor, ProcessorStatus
 
 
 class ChanProcessor(BaseProcessor):
@@ -15,9 +15,9 @@ class ChanProcessor(BaseProcessor):
         logger.info(f"Starting processing of Chan file: {self.file_path}")
 
         try:
-            status: int = self.read_maximums_csv()
+            status: ProcessorStatus = self.read_maximums_csv()
 
-            if status != 0:
+            if status is not ProcessorStatus.SUCCESS:
                 logger.error(f"Processing aborted for file: {self.file_path} due to previous errors.")
                 self.df = pd.DataFrame()
                 return self.df

--- a/ryan_library/processors/tuflow/CmxProcessor.py
+++ b/ryan_library/processors/tuflow/CmxProcessor.py
@@ -1,8 +1,8 @@
 # ryan_library/processors/tuflow/cmx_processor.py
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 from loguru import logger
-from .base_processor import BaseProcessor
+from .base_processor import BaseProcessor, ProcessorStatus
 
 
 class CmxProcessor(BaseProcessor):
@@ -13,9 +13,9 @@ class CmxProcessor(BaseProcessor):
         logger.info(f"Starting processing of CMX file: {self.file_path}")
 
         try:
-            status = self.read_maximums_csv()
+            status: ProcessorStatus = self.read_maximums_csv()
 
-            if status != 0:
+            if status is not ProcessorStatus.SUCCESS:
                 logger.error(f"Processing aborted for file: {self.file_path} due to previous errors.")
                 self.df = pd.DataFrame()
                 return

--- a/ryan_library/processors/tuflow/NmxProcessor.py
+++ b/ryan_library/processors/tuflow/NmxProcessor.py
@@ -1,8 +1,8 @@
 # ryan_library/processors/tuflow/nmx_processor.py
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 from loguru import logger
-from .base_processor import BaseProcessor
+from .base_processor import BaseProcessor, ProcessorStatus
 
 
 # this processor does not understand pits - only index 1 or 2 for standard culverts
@@ -22,9 +22,9 @@ class NmxProcessor(BaseProcessor):
 
         try:
             # Nmx is Maximums type, so use read_maximums_csv
-            status = self.read_maximums_csv()
+            status: ProcessorStatus = self.read_maximums_csv()
 
-            if status != 0:
+            if status is not ProcessorStatus.SUCCESS:
                 logger.error(
                     f"Processing aborted for file: {self.file_path} due to previous errors."
                 )

--- a/ryan_library/processors/tuflow/QProcessor.py
+++ b/ryan_library/processors/tuflow/QProcessor.py
@@ -1,39 +1,45 @@
 # ryan_library/processors/tuflow/QProcessor.py
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 from loguru import logger
-from .base_processor import BaseProcessor, DataValidationError, ProcessorError
+
+from .base_processor import DataValidationError, ProcessorError, ProcessorStatus
+from .timeseries_processor import TimeSeriesProcessor
 
 
-class QProcessor(BaseProcessor):
-    """Processor for '_Q' Timeseries CSV files."""
+class QProcessor(TimeSeriesProcessor):
+    """Processor for ``_Q`` timeseries CSV outputs."""
 
     def process(self) -> pd.DataFrame:
-        """
-        Process the '_Q' timeseries CSV file and return a cleaned DataFrame.
+        """Run the shared pipeline and Q-specific reshape for a ``_Q`` CSV.
+
+        The method orchestrates each step of the processing workflow:
+
+        1. Invoke :meth:`read_and_process_timeseries_csv` to read and tidy the
+           raw TUFLOW export.
+        2. Normalise the melted discharge values via
+           :meth:`process_timeseries_raw_dataframe`.
+        3. Append metadata columns, apply configured dtype conversions and
+           validate the resulting frame before returning it.
 
         Returns:
-            pd.DataFrame: Processed Q data.
+            pandas.DataFrame: Processed Q-series observations.
         """
         logger.info(f"Starting processing of Q file: {self.file_path}")
 
         try:
             # Step 1: Read and process the timeseries CSV with 'Q' as the data type
-            status: int = self.read_and_process_timeseries_csv(data_type="Q")
+            status: ProcessorStatus = self.read_and_process_timeseries_csv(data_type="Q")
 
-            if status != 0:
-                logger.error(
-                    f"Processing aborted for file: {self.file_path} due to previous errors."
-                )
+            if status is not ProcessorStatus.SUCCESS:
+                logger.error(f"Processing aborted for file: {self.file_path} due to previous errors.")
                 self.df = pd.DataFrame()
                 return self.df
 
             # Step 2: Further process the reshaped DataFrame if necessary
             status = self.process_timeseries_raw_dataframe()
-            if status != 0:
-                logger.error(
-                    f"Processing aborted for file: {self.file_path} during raw dataframe processing."
-                )
+            if status is not ProcessorStatus.SUCCESS:
+                logger.error(f"Processing aborted for file: {self.file_path} during raw dataframe processing.")
                 self.df = pd.DataFrame()
                 return self.df
 
@@ -59,70 +65,60 @@ class QProcessor(BaseProcessor):
             self.df = pd.DataFrame()
             return self.df
 
-    def process_timeseries_raw_dataframe(self) -> int:
-        """Process the raw reshaped timeseries DataFrame by melting Q columns into a long format.
+    def process_timeseries_raw_dataframe(self) -> ProcessorStatus:
+        """Normalise the long-form ``Q`` DataFrame produced by the shared pipeline.
+
+        The shared reader trims the leading ``"Q "`` prefix and any bracketed
+        unit descriptors from the raw column headers (for example ``"Q ds1
+        [M11_5m_001]"`` becomes ``"ds1"``).  This helper keeps whichever
+        identifier column was created during the melt (``"Chan ID"`` for 1D
+        exports or ``"Location"`` for 2D), removes empty discharge values and
+        re-confirms the headers so downstream validation behaves predictably.
 
         Returns:
-            int: Status code.
-                0 - Success
-                1 - Empty DataFrame after processing
-                2 - Header mismatch after processing
-                3 - Processing error"""
+            ProcessorStatus: Status flag following the shared convention used by
+            :class:`~ryan_library.processors.tuflow.base_processor.BaseProcessor`.
+        """
         try:
-            logger.debug("Starting to process the raw timeseries DataFrame for Q data.")
+            logger.debug("Normalising the melted Q DataFrame produced by the shared pipeline.")
 
-            # Identify Q columns (e.g., "Q ds1", "Q ds2", "Q ds3")
-            q_columns = [col for col in self.df.columns if col.startswith("Q ds")]
-            logger.debug(f"Identified Q columns: {q_columns}")
+            identifier_columns = [col for col in self.df.columns if col not in {"Time", "Q"}]
+            if len(identifier_columns) != 1:
+                logger.error(
+                    f"{self.file_name}: Expected a single identifier column alongside 'Time' and 'Q', got {identifier_columns}."
+                )
+                return ProcessorStatus.FAILURE
 
-            if not q_columns:
-                logger.error("No Q columns found in the DataFrame.")
-                return 3
+            identifier_column: str = identifier_columns[0]
+            logger.debug(f"Using '{identifier_column}' as the identifier column for Q values.")
 
-            # Melt the Q columns to transform from wide to long format
-            df_melted = self.df.melt(
-                id_vars=["Time"], value_vars=q_columns, var_name="ds", value_name="Q"
-            )
-            logger.debug(f"Melted DataFrame shape: {df_melted.shape}")
+            # Drop rows with missing Q values to avoid empty observations downstream
+            initial_row_count = len(self.df)
+            self.df.dropna(subset=["Q"], inplace=True)
+            final_row_count = len(self.df)
+            dropped_rows = initial_row_count - final_row_count
+            if dropped_rows:
+                logger.debug(f"Dropped {dropped_rows} rows with missing Q values.")
 
-            # Extract ds identifier (e.g., 'ds1', 'ds2', 'ds3') from the 'ds' column
-            df_melted["ds"] = df_melted["ds"].str.extract(r"(ds\d+)")
+            if self.df.empty:
+                logger.error("DataFrame is empty after removing rows with missing Q values.")
+                return ProcessorStatus.EMPTY_DATAFRAME
 
-            # Drop rows with missing Q values
-            initial_row_count = len(df_melted)
-            df_melted.dropna(subset=["Q"], inplace=True)
-            final_row_count = len(df_melted)
-            logger.debug(
-                f"Dropped {initial_row_count - final_row_count} rows with missing Q values."
-            )
-
-            if df_melted.empty:
-                logger.error("DataFrame is empty after melting Q columns.")
-                return 1
-
-            # Assign the melted DataFrame back to self.df
-            self.df = df_melted
-
-            # Validate headers after melting
-            expected_headers = ["Time", "ds", "Q"]
+            # Validate headers after normalisation
             if not self.check_headers_match(test_headers=self.df.columns.tolist()):
                 logger.error(f"{self.file_name}: Header mismatch after melting.")
-                return 2
+                return ProcessorStatus.HEADER_MISMATCH
 
-            logger.info(
-                f"{self.file_name}: Successfully melted Q columns into long format."
-            )
+            logger.info(f"{self.file_name}: Successfully normalised Q DataFrame for downstream processing.")
 
-            return 0
+            return ProcessorStatus.SUCCESS
 
         except DataValidationError as dve:
             logger.error(f"{self.file_name}: Data validation error: {dve}")
-            return 3
+            return ProcessorStatus.FAILURE
         except ProcessorError as pe:
             logger.error(f"{self.file_name}: Processor error: {pe}")
-            return 3
+            return ProcessorStatus.FAILURE
         except Exception as e:
-            logger.exception(
-                f"{self.file_name}: Unexpected error during processing: {e}"
-            )
-            return 3
+            logger.exception(f"{self.file_name}: Unexpected error during processing: {e}")
+            return ProcessorStatus.FAILURE

--- a/ryan_library/processors/tuflow/base_processor.py
+++ b/ryan_library/processors/tuflow/base_processor.py
@@ -2,10 +2,11 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from enum import IntEnum
 from pathlib import Path
 from typing import Any, ClassVar, cast
 import importlib
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 from loguru import logger
 from ryan_library.classes.suffixes_and_dtypes import (
     Config,
@@ -32,6 +33,16 @@ class ImportProcessorError(ProcessorError):
 
 class DataValidationError(ProcessorError):
     """Exception raised for data validation errors."""
+
+
+# Standard status codes returned by processor helpers.
+class ProcessorStatus(IntEnum):
+    """Named status codes shared by processor helpers."""
+
+    SUCCESS = 0
+    EMPTY_DATAFRAME = 1
+    HEADER_MISMATCH = 2
+    FAILURE = 3
 
 
 # the processors are imported as required within the class (importlib)
@@ -336,11 +347,20 @@ class BaseProcessor(ABC):
             logger.warning(f"{self.file_name}: No headers to validate against.")
             return True
 
-    def read_maximums_csv(self) -> int:
-        """Reads CSV files with 'Maximums' or 'ccA' dataformat.
+    def read_maximums_csv(self) -> ProcessorStatus:
+        """Read a ``Maximums`` or ``ccA`` CSV into :attr:`self.df`.
+
+        The helper uses the configuration on the processor instance to select
+        the expected columns, loads the file and validates the header order
+        before storing the DataFrame on the object.
 
         Returns:
-             int: status code."""
+            ProcessorStatus: ``ProcessorStatus.SUCCESS`` if the CSV was loaded
+            successfully. ``ProcessorStatus.EMPTY_DATAFRAME`` signals a file
+            without data, ``ProcessorStatus.HEADER_MISMATCH`` indicates the
+            headers did not align with the configuration and
+            ``ProcessorStatus.FAILURE`` captures read failures.
+        """
         usecols = list(self.columns_to_use.keys())
         dtype: dict[str, str] = {col: self.columns_to_use[col] for col in usecols}
 
@@ -355,229 +375,29 @@ class BaseProcessor(ABC):
             logger.debug(f"CSV file '{self.file_name}' read successfully with {len(df)} rows.")
         except Exception as e:
             logger.exception(f"{self.file_name}: Failed to read CSV file '{self.file_path}': {e}")
-            return 3
+            return ProcessorStatus.FAILURE
 
         if df.empty:
             logger.error(f"{self.file_name}: No data found in file: {self.file_path}")
-            return 1
+            return ProcessorStatus.EMPTY_DATAFRAME
 
         # Validate headers
         if not self.check_headers_match(df.columns.tolist()):
-            return 2
+            return ProcessorStatus.HEADER_MISMATCH
 
         self.df = df
-        return 0
-
-    def read_and_process_timeseries_csv(self, data_type: str) -> int:
-        """Reads and processes timeseries CSV files, including cleaning headers and reshaping data.
-
-        Args:
-            data_type (str): The data type identifier (e.g., 'H', 'Q').
-
-        Returns:
-            int: Status code.
-                0 - Success
-                1 - Empty DataFrame
-                2 - Header mismatch
-                3 - Read or processing error"""
-        try:
-            df_full: pd.DataFrame = self._read_csv(file_path=self.file_path)
-            if df_full.empty:
-                logger.error(f"{self.file_name}: No data found in file: {self.file_path}")
-                return 1
-
-            df: pd.DataFrame = self._clean_headers(df=df_full, data_type=data_type)
-            if df.empty:
-                logger.error(f"{self.file_name}: DataFrame is empty after cleaning headers.")
-                return 1
-
-            df_melted: pd.DataFrame = self._reshape_timeseries_df(df=df, data_type=data_type)
-            if df_melted.empty:
-                logger.error(f"{self.file_name}: No data found after reshaping.")
-                return 1
-
-            self.df = df_melted
-            self._apply_final_transformations(data_type=data_type)
-            self.processed = True  # Mark as processed
-            logger.info(f"{self.file_name}: Timeseries CSV processed successfully.")
-            return 0
-        except (ProcessorError, DataValidationError) as e:
-            logger.error(f"{self.file_name}: Processing error: {e}")
-            return 3
-        except Exception as e:
-            logger.exception(f"{self.file_name}: Unexpected error: {e}")
-            return 3
-
-    def _read_csv(self, file_path: Path) -> pd.DataFrame:
-        try:
-            df: pd.DataFrame = pd.read_csv(
-                filepath_or_buffer=file_path,
-                header=0,
-                skipinitialspace=True,
-                encoding="utf-8",
-            )
-            logger.debug(f"CSV file '{self.file_name}' read successfully with {len(df)} rows.")
-            return df
-        except Exception as e:
-            logger.exception(f"{self.file_name}: Failed to read CSV file '{file_path}': {e}")
-            raise ProcessorError(f"Failed to read CSV file '{file_path}': {e}")
-
-    def _clean_headers(self, df: pd.DataFrame, data_type: str) -> pd.DataFrame:
-        try:
-            df = df.drop(labels=df.columns[0], axis=1)
-            logger.debug(f"Dropped the first column from '{self.file_path}'.")
-
-            if "Time (h)" in df.columns:
-                df.rename(columns={"Time (h)": "Time"}, inplace=True)
-                logger.debug("Renamed 'Time (h)' to 'Time'.")
-
-            if "Time" not in df.columns:
-                logger.error(f"{self.file_name}: 'Time' column is missing after cleaning headers.")
-                raise DataValidationError("'Time' column is missing after cleaning headers.")
-
-            cleaned_columns: list[str] = self._clean_column_names(columns=df.columns, data_type=data_type)
-            df.columns = cleaned_columns
-            logger.debug(f"Cleaned headers: {cleaned_columns}")
-            return df
-        except Exception as e:
-            logger.exception(f"{self.file_name}: Failed to clean headers: {e}")
-            raise ProcessorError(f"Failed to clean headers: {e}")
-
-    def _clean_column_names(self, columns: pd.Index, data_type: str) -> list[str]:
-        cleaned_columns: list[str] = []
-        for col in columns:
-            if col.startswith(f"{data_type} "):
-                col_clean: str = col[len(data_type) + 1 :]
-            else:
-                col_clean = col
-
-            if "[" in col_clean and "]" in col_clean:
-                col_clean = col_clean.split("[")[0].strip()
-
-            cleaned_columns.append(col_clean)
-        return cleaned_columns
-
-    def _reshape_timeseries_df(self, df: pd.DataFrame, data_type: str) -> pd.DataFrame:
-        """Reshape the timeseries DataFrame based on the data type.
-
-        Headers are validated against a dynamically built list via ``check_headers_match``.
-
-        Args:
-            df (pd.DataFrame): The cleaned DataFrame.
-            data_type (str): The data type identifier.
-
-        Returns:
-            pd.DataFrame: The reshaped DataFrame.
-        """
-        is_1d: bool = "_1d_" in self.file_name.lower()
-        category_type: str = "Chan ID" if is_1d else "Location"
-        logger.debug(
-            f"{self.file_name}: {'1D' if is_1d else '2D'} filename detected; using '{category_type}' as category type."
-        )
-
-        try:
-            if data_type == "H":
-                df_melted: pd.DataFrame = self._reshape_h_data(df=df, category_type=category_type)
-            else:
-                # For data types like 'Q', 'F', 'V' with single value per channel
-                df_melted = df.melt(id_vars=["Time"], var_name=category_type, value_name=data_type)
-                logger.debug(f"Reshaped DataFrame to long format with {len(df_melted)} rows.")
-        except Exception as e:
-            logger.exception(f"{self.file_name}: Failed to reshape DataFrame: {e}")
-            raise ProcessorError(f"Failed to reshape DataFrame: {e}")
-
-        if df_melted.empty:
-            logger.error(f"{self.file_name}: No data found after reshaping.")
-            raise DataValidationError("No data found after reshaping.")
-
-        # Validate headers
-        # Build the expected header list dynamically. It always starts with "Time" and the
-        # category column, which switches between "Chan ID" for 1D results and "Location" for
-        # 2D results. For "H" data types, both "H_US" and "H_DS" are expected; otherwise the
-        # single data type column is used. ``check_headers_match`` validates against this list.
-        expected_headers: list[str] = (
-            ["Time", category_type, "H_US", "H_DS"] if data_type == "H" else ["Time", category_type, data_type]
-        )
-        self.expected_in_header = expected_headers
-        if not self.check_headers_match(test_headers=df_melted.columns.tolist()):
-            logger.error(f"{self.file_name}: Header mismatch after reshaping.")
-            raise DataValidationError("Header mismatch after reshaping.")
-
-        return df_melted
-
-    def _reshape_h_data(self, df: pd.DataFrame, category_type: str) -> pd.DataFrame:
-        """Special handling for 'H' data type which has 'H_US' and 'H_DS' per channel.
-        # Assuming headers are like 'H_US', 'H_DS' for each channel
-        # We need to reshape such that each channel has two entries per time: 'H_US' and 'H_DS'
-        # Alternatively, we can create separate columns for 'H_US' and 'H_DS'
-        # For simplicity, we'll assume each channel has both 'H_US' and 'H_DS' and reshape accordingly
-
-        # First, verify that for each channel, both 'H_US' and 'H_DS' exist
-        Args:
-            df (pd.DataFrame): The cleaned DataFrame.
-            category_type (str): The category type identifier.
-
-        Returns:
-            pd.DataFrame: The reshaped DataFrame."""
-        # Extract channel identifiers by removing suffixes
-        channels = set()
-        for col in df.columns:
-            if col.endswith("_US") or col.endswith("_DS"):
-                channels.add(col.rsplit("_", 1)[0])
-
-        records = []
-        for _, row in df.iterrows():
-            time = row["Time"]
-            for chan in channels:
-                h_us = row.get(f"{chan}_US", -9999.0)
-                h_ds = row.get(f"{chan}_DS", -9999.0)
-                records.append(
-                    {
-                        "Time": time,
-                        category_type: chan,
-                        "H_US": h_us,
-                        "H_DS": h_ds,
-                    }
-                )
-
-        df_melted = pd.DataFrame(data=records)
-        logger.debug(f"Reshaped 'H' DataFrame to long format with {len(df_melted)} rows.")
-        return df_melted
-
-    def _apply_final_transformations(self, data_type: str) -> None:
-        """Apply final transformations to the DataFrame after reshaping.
-
-        Args:
-            data_type (str): The data type identifier."""
-        col_types: dict[str, str] = {
-            "Time": "float64",
-            data_type: "float64",
-        }
-
-        if data_type == "H":
-            col_types.update({"H_US": "float64", "H_DS": "float64"})
-
-        self.apply_dtype_mapping(dtype_mapping=col_types, context="final_transformations")
-
-    def read_ccA_data(self) -> tuple[pd.DataFrame, int]:
-        """Reads ccA files with 'ccA' data format.
-
-        Returns:
-            tuple[pd.DataFrame, int]: DataFrame and status code.
-                Status Codes:
-                    0 - Success
-                    1 - Empty DataFrame
-                    2 - Header mismatch
-                    3 - Read error"""
-        # 'ccA' cannot be processed yet; raise NotImplementedError
-        raise NotImplementedError("Processing of ccA data format is not yet implemented.")
+        return ProcessorStatus.SUCCESS
 
     def apply_dtype_mapping(self, dtype_mapping: dict[str, str], context: str = "") -> None:
         """Apply dtype mapping to the DataFrame.
 
         Args:
             dtype_mapping (dict[str, str]): Mapping of column names to data types.
-            context (str): Contextual information for logging."""
+            context (str): Contextual information for logging.
+
+        Raises:
+            ProcessorError: If :meth:`pandas.DataFrame.astype` fails for any column.
+        """
         try:
             self.df = self.df.astype(dtype=dtype_mapping)
             logger.debug(f"{self.file_name}: Applied dtype mapping in {context}: {dtype_mapping}")

--- a/ryan_library/processors/tuflow/max_data_processor.py
+++ b/ryan_library/processors/tuflow/max_data_processor.py
@@ -1,19 +1,15 @@
 # ryan_library/processors/tuflow/max_data_processor.py
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 from loguru import logger
-from .base_processor import BaseProcessor, DataValidationError, ProcessorError
+from .base_processor import BaseProcessor, DataValidationError, ProcessorError, ProcessorStatus
 
 
 class MaxDataProcessor(BaseProcessor):
     """Intermediate base class for processing maximum data types."""
 
-    def read_maximums_csv(self) -> int:
-        """Reads CSV files with 'Maximums' or 'ccA' dataformat.
-
-        Returns:
-             int: status code.
-        """
+    def read_maximums_csv(self) -> ProcessorStatus:
+        """Read ``Maximums`` or ``ccA`` CSV files and return a status flag."""
         # [Implementation as previously defined in BaseProcessor]
         # You might move the read_maximums_csv from BaseProcessor to here.
         # Or if already in BaseProcessor, ensure it's only used by MaxDataProcessor

--- a/ryan_library/processors/tuflow/timeseries_helpers.py
+++ b/ryan_library/processors/tuflow/timeseries_helpers.py
@@ -1,0 +1,33 @@
+"""Utility helpers shared by TUFLOW timeseries processors."""
+
+from __future__ import annotations
+
+import pandas as pd  # type: ignore[import-untyped]
+from loguru import logger
+
+
+def reshape_h_timeseries(df: pd.DataFrame, category_type: str, file_label: str) -> pd.DataFrame:
+    """Convert H timeseries data with upstream/downstream suffixes into a long format DataFrame."""
+    if "Time" not in df.columns:
+        raise ValueError("DataFrame must contain a 'Time' column before reshaping H data.")
+
+    suffixes: tuple[str, str] = ("_US", "_DS")
+    channels: list[str] = sorted({col.rsplit("_", 1)[0] for col in df.columns if col.endswith(suffixes)})
+    if not channels:
+        raise ValueError("No channel columns with '_US' or '_DS' suffixes were found in the DataFrame.")
+
+    records: list[dict[str, object]] = []
+    for _, row in df.iterrows():
+        time_value = row["Time"]
+        for channel_id in channels:
+            record: dict[str, object] = {
+                "Time": time_value,
+                category_type: channel_id,
+                "H_US": row.get(f"{channel_id}_US", -9999.0),
+                "H_DS": row.get(f"{channel_id}_DS", -9999.0),
+            }
+            records.append(record)
+
+    reshaped_df = pd.DataFrame(records)
+    logger.debug(f"{file_label}: Reshaped 'H' DataFrame to long format with {len(reshaped_df)} rows.")
+    return reshaped_df

--- a/ryan_library/processors/tuflow/timeseries_processor.py
+++ b/ryan_library/processors/tuflow/timeseries_processor.py
@@ -1,118 +1,234 @@
 # ryan_library/processors/tuflow/timeseries_processor.py
 
-import pandas as pd
+from __future__ import annotations
+
+from abc import abstractmethod
+from pathlib import Path
+
+import pandas as pd  # type: ignore[import-untyped]
 from loguru import logger
-from .base_processor import BaseProcessor, DataValidationError, ProcessorError
+
+from .base_processor import (
+    BaseProcessor,
+    DataValidationError,
+    ProcessorError,
+    ProcessorStatus,
+)
+from .timeseries_helpers import reshape_h_timeseries
 
 
 class TimeSeriesProcessor(BaseProcessor):
-    """Intermediate base class for processing timeseries data types."""
+    """Base class for processors that operate on TUFLOW timeseries outputs.
 
-    def process_timeseries_raw_dataframe(self, data_type: str) -> int:
-        """
-        Process the raw reshaped timeseries DataFrame by melting or transforming as needed.
+    The class centralises the shared read → clean → reshape pipeline required by
+    every timeseries dataset before delegating to
+    :meth:`process_timeseries_raw_dataframe` for format-specific transforms.
+    """
+
+    @abstractmethod
+    def process_timeseries_raw_dataframe(self) -> ProcessorStatus:
+        """Transform :attr:`self.df` after the common pipeline finishes.
+
+        Implementations should update :attr:`self.df` in place and return a
+        :class:`~ryan_library.processors.tuflow.base_processor.ProcessorStatus`
+        describing the outcome of the subclass-specific processing.
 
         Returns:
-            int: Status code.
+            ProcessorStatus: Status flag indicating success or the failure reason.
         """
-        # Implement the common process_timeseries_raw_dataframe logic here
+        raise NotImplementedError
+
+    def read_and_process_timeseries_csv(self, data_type: str) -> ProcessorStatus:
+        """Read, clean and reshape a timeseries CSV into :attr:`self.df`.
+
+        Args:
+            data_type: Abbreviation describing the numeric values contained in the
+                file (for example ``"H"`` or ``"Q"``). The identifier drives how
+                the DataFrame is reshaped and which value columns are created.
+
+        Returns:
+            ProcessorStatus: Status code following the same convention as
+            :meth:`process_timeseries_raw_dataframe`.
+        """
         try:
-            logger.debug("Starting to process the raw timeseries DataFrame.")
+            df_full: pd.DataFrame = self._read_csv(file_path=self.file_path)
+            if df_full.empty:
+                logger.error(f"{self.file_name}: No data found in file: {self.file_path}")
+                return ProcessorStatus.EMPTY_DATAFRAME
 
-            # This method can be abstracted based on data_type
-            if data_type == "H":
-                return self._process_h_timeseries()
-            elif data_type == "Q":
-                return self._process_q_timeseries()
-            else:
-                logger.error(
-                    f"Unsupported data_type '{data_type}' for timeseries processing."
-                )
-                return 3
+            df_clean: pd.DataFrame = self._clean_headers(df=df_full, data_type=data_type)
+            if df_clean.empty:
+                logger.error(f"{self.file_name}: DataFrame is empty after cleaning headers.")
+                return ProcessorStatus.EMPTY_DATAFRAME
 
-        except (DataValidationError, ProcessorError) as e:
-            logger.error(f"{self.file_name}: Processing error: {e}")
-            return 3
-        except Exception as e:
-            logger.exception(f"{self.file_name}: Unexpected error: {e}")
-            return 3
-
-    def _process_q_timeseries(self) -> int:
-        """Process 'Q' timeseries data."""
-        try:
-            # Identify Q columns (e.g., "Q ds1", "Q ds2", "Q ds3")
-            q_columns = [col for col in self.df.columns if col.startswith("Q ds")]
-            logger.debug(f"Identified Q columns: {q_columns}")
-
-            if not q_columns:
-                logger.error("No Q columns found in the DataFrame.")
-                return 3
-
-            # Melt the Q columns to transform from wide to long format
-            df_melted = self.df.melt(
-                id_vars=["Time"], value_vars=q_columns, var_name="ds", value_name="Q"
-            )
-            logger.debug(f"Melted DataFrame shape: {df_melted.shape}")
-
-            # Extract ds identifier (e.g., 'ds1', 'ds2', 'ds3') from the 'ds' column
-            df_melted["ds"] = df_melted["ds"].str.extract(r"(ds\d+)")
-
-            # Drop rows with missing Q values
-            initial_row_count = len(df_melted)
-            df_melted.dropna(subset=["Q"], inplace=True)
-            final_row_count = len(df_melted)
-            logger.debug(
-                f"Dropped {initial_row_count - final_row_count} rows with missing Q values."
-            )
-
+            df_melted: pd.DataFrame = self._reshape_timeseries_df(df=df_clean, data_type=data_type)
             if df_melted.empty:
-                logger.error("DataFrame is empty after melting Q columns.")
-                return 1
+                logger.error(f"{self.file_name}: No data found after reshaping.")
+                return ProcessorStatus.EMPTY_DATAFRAME
 
-            # Assign the melted DataFrame back to self.df
             self.df = df_melted
+            self._apply_final_transformations(data_type=data_type)
+            self.processed = True  # Mark as processed once the shared pipeline completes
+            logger.info(f"{self.file_name}: Timeseries CSV processed successfully.")
+            return ProcessorStatus.SUCCESS
+        except (ProcessorError, DataValidationError) as exc:
+            logger.error(f"{self.file_name}: Processing error: {exc}")
+            return ProcessorStatus.FAILURE
+        except Exception as exc:
+            logger.exception(f"{self.file_name}: Unexpected error: {exc}")
+            return ProcessorStatus.FAILURE
 
-            # Validate headers after melting
-            expected_headers = ["Time", "ds", "Q"]
-            if not self.check_headers_match(test_headers=self.df.columns.tolist()):
-                logger.error(f"{self.file_name}: Header mismatch after melting.")
-                return 2
+    def _read_csv(self, file_path: Path) -> pd.DataFrame:
+        """Return the raw timeseries CSV as a DataFrame using shared options.
 
-            logger.info(
-                f"{self.file_name}: Successfully melted Q columns into long format."
-            )
+        Args:
+            file_path: Location of the CSV produced by TUFLOW.
 
-            return 0
+        Returns:
+            pandas.DataFrame: Raw data read from ``file_path``.
 
-        except Exception as e:
-            logger.exception(
-                f"{self.file_name}: Failed to process Q timeseries data: {e}"
-            )
-            return 3
-
-    def _process_h_timeseries(self) -> int:
-        """Process 'H' timeseries data."""
+        Raises:
+            ProcessorError: If :mod:`pandas` fails to load the file.
+        """
         try:
-            # Implement the H timeseries processing logic
-            # This could include methods like _reshape_h_data, etc.
-            # Similar to what was outlined in your original QProcessor
-
-            # Example:
-            category_type = (
-                "Chan ID" if "1d" in self.name_parser.suffixes else "Location"
+            df: pd.DataFrame = pd.read_csv(
+                filepath_or_buffer=file_path,
+                header=0,
+                skipinitialspace=True,
+                encoding="utf-8",
             )
-            df_melted = self._reshape_h_data(df=self.df, category_type=category_type)
-            self.df = df_melted
-            self._apply_final_transformations(data_type="H")
-            self.processed = True
-            logger.info(f"{self.file_name}: Successfully processed H timeseries data.")
+            logger.debug(f"CSV file '{self.file_name}' read successfully with {len(df)} rows.")
+            return df
+        except Exception as exc:
+            logger.exception(f"{self.file_name}: Failed to read CSV file '{file_path}': {exc}")
+            raise ProcessorError(f"Failed to read CSV file '{file_path}': {exc}") from exc
 
-            return 0
+    def _clean_headers(self, df: pd.DataFrame, data_type: str) -> pd.DataFrame:
+        """Normalise the header row before reshaping timeseries data.
 
-        except Exception as e:
-            logger.exception(
-                f"{self.file_name}: Failed to process H timeseries data: {e}"
-            )
-            return 3
+        The exported CSVs include a blank descriptor column and occasionally use
+        ``"Time (h)"`` in place of ``"Time"``. This helper removes the redundant
+        column, ensures a ``"Time"`` field exists and trims the ``data_type`` prefix
+        as well as any unit suffixes.
 
-    # Implement any additional shared timeseries processing methods here
+        Args:
+            df: Raw DataFrame returned by :meth:`_read_csv`.
+            data_type: Identifier for the value columns within ``df``.
+
+        Returns:
+            pandas.DataFrame: DataFrame with consistent headers ready for reshaping.
+
+        Raises:
+            ProcessorError: If the DataFrame cannot be cleaned or lacks a ``"Time"``
+                column.
+        """
+        try:
+            df = df.drop(labels=df.columns[0], axis=1)
+            logger.debug(f"Dropped the first column from '{self.file_path}'.")
+
+            if "Time (h)" in df.columns:
+                df.rename(columns={"Time (h)": "Time"}, inplace=True)
+                logger.debug("Renamed 'Time (h)' to 'Time'.")
+
+            if "Time" not in df.columns:
+                logger.error(f"{self.file_name}: 'Time' column is missing after cleaning headers.")
+                raise DataValidationError("'Time' column is missing after cleaning headers.")
+
+            cleaned_columns: list[str] = self._clean_column_names(columns=df.columns, data_type=data_type)
+            df.columns = cleaned_columns
+            logger.debug(f"Cleaned headers: {cleaned_columns}")
+            return df
+        except Exception as exc:
+            logger.exception(f"{self.file_name}: Failed to clean headers: {exc}")
+            raise ProcessorError(f"Failed to clean headers: {exc}") from exc
+
+    def _clean_column_names(self, columns: pd.Index, data_type: str) -> list[str]:
+        """Strip prefixes and unit suffixes from a sequence of column names.
+
+        Args:
+            columns: Columns to normalise.
+            data_type: Identifier prefix included in the exported headers.
+
+        Returns:
+            list[str]: Cleaned column names with redundant descriptors removed.
+        """
+        cleaned_columns: list[str] = []
+        for col in columns:
+            if col.startswith(f"{data_type} "):
+                col_clean: str = col[len(data_type) + 1 :]
+            else:
+                col_clean = col
+
+            if "[" in col_clean and "]" in col_clean:
+                # Example: "Q ds1 [M11_5m_001]" becomes "ds1"
+                col_clean = col_clean.split("[")[0].strip()
+
+            cleaned_columns.append(col_clean)
+        return cleaned_columns
+
+    def _reshape_timeseries_df(self, df: pd.DataFrame, data_type: str) -> pd.DataFrame:
+        """Reshape the cleaned DataFrame into a tidy, long-form structure.
+
+        Args:
+            df: Cleaned DataFrame containing a ``"Time"`` column and value columns.
+            data_type: Identifier for the numeric series in ``df``.
+
+        Returns:
+            pandas.DataFrame: Melted DataFrame with consistent column ordering.
+
+        Raises:
+            ProcessorError: If melting fails for any reason.
+            DataValidationError: If the resulting DataFrame is empty or the headers
+                do not match the expected structure.
+        """
+        is_1d: bool = "_1d_" in self.file_name.lower()
+        category_type: str = "Chan ID" if is_1d else "Location"
+        logger.debug(
+            f"{self.file_name}: {'1D' if is_1d else '2D'} filename detected; using '{category_type}' as category type."
+        )
+
+        try:
+            if data_type == "H":
+                df_melted: pd.DataFrame = reshape_h_timeseries(
+                    df=df, category_type=category_type, file_label=self.file_name
+                )
+            else:
+                df_melted = df.melt(id_vars=["Time"], var_name=category_type, value_name=data_type)
+                logger.debug(f"Reshaped DataFrame to long format with {len(df_melted)} rows.")
+        except Exception as exc:
+            logger.exception(f"{self.file_name}: Failed to reshape DataFrame: {exc}")
+            raise ProcessorError(f"Failed to reshape DataFrame: {exc}") from exc
+
+        if df_melted.empty:
+            logger.error(f"{self.file_name}: No data found after reshaping.")
+            raise DataValidationError("No data found after reshaping.")
+
+        expected_headers: list[str] = (
+            ["Time", category_type, "H_US", "H_DS"] if data_type == "H" else ["Time", category_type, data_type]
+        )
+        # Build the expected header list dynamically. It always starts with "Time" and the
+        # category column, which switches between "Chan ID" for 1D results and "Location" for
+        # 2D results. For "H" data types, both "H_US" and "H_DS" are expected; otherwise the
+        # single data type column is used. ``check_headers_match`` validates against this list.
+        self.expected_in_header = expected_headers
+        if not self.check_headers_match(test_headers=df_melted.columns.tolist()):
+            logger.error(f"{self.file_name}: Header mismatch after reshaping.")
+            raise DataValidationError("Header mismatch after reshaping.")
+
+        return df_melted
+
+    def _apply_final_transformations(self, data_type: str) -> None:
+        """Apply dtype coercions expected by downstream consumers.
+
+        Args:
+            data_type: Identifier of the main numeric value column in ``self.df``.
+        """
+        col_types: dict[str, str] = {
+            "Time": "float64",
+            data_type: "float64",
+        }
+
+        if data_type == "H":
+            col_types.update({"H_US": "float64", "H_DS": "float64"})
+
+        self.apply_dtype_mapping(dtype_mapping=col_types, context="final_transformations")


### PR DESCRIPTION
## Summary
- keep the identifier column generated by the shared timeseries melt (``Chan ID``/``Location``) instead of renaming it to ``ds``
- update the Q processor docstring to explain that arbitrary identifiers are retained while empty discharge rows are dropped

## Testing
- mypy --follow-imports=skip ryan_library/processors/tuflow/base_processor.py ryan_library/processors/tuflow/timeseries_processor.py ryan_library/processors/tuflow/QProcessor.py

------
https://chatgpt.com/codex/tasks/task_e_68c9547947a0832e94438560f55c21b8