### PR TITLE
[devx] Add ensure venv helper for Codex sessions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  // Update this path if you prefer a different interpreter than the recommended .venv
+  // (expect more approval prompts when the path changes between sessions).
+  "python.defaultInterpreterPath": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
+  "python.terminal.activateEnvironment": true,
+  "python.analysis.indexing": true,
+  "terminal.integrated.defaultProfile.windows": "PowerShell",
+  "terminal.integrated.profiles.windows": {
+    "PowerShell": {
+      "path": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+    }
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "python:ensure-venv",
+      "type": "shell",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-Command",
+        "$python = if (Test-Path '${workspaceFolder}\\.venv\\Scripts\\python.exe') { '${workspaceFolder}\\.venv\\Scripts\\python.exe' } elseif ($env:RYAN_TOOLS_PYTHON) { $env:RYAN_TOOLS_PYTHON } else { 'python' }; & $python '${workspaceFolder}\\repo-scripts\\ensure_venv.py'"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "python:stdin",
+      "type": "shell",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-Command",
+        "$python = if (Test-Path '${workspaceFolder}\\.venv\\Scripts\\python.exe') { '${workspaceFolder}\\.venv\\Scripts\\python.exe' } elseif ($env:RYAN_TOOLS_PYTHON) { $env:RYAN_TOOLS_PYTHON } else { 'python' }; $snippet = if ($env:RYAN_TOOLS_SNIPPET) { $env:RYAN_TOOLS_SNIPPET } else { '${workspaceFolder}\\repo-scripts\\run_snippet.py' }; Get-Content -Raw - | & $python $snippet"
+      ],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -32,3 +32,33 @@ Lots of others at varying levels of quality.
 
 Pretty much no tests.
 
+## VS Code + Codex agent setup on Windows
+
+### 1. Pick a Python interpreter
+
+* **Recommended – repo-local virtual environment**. Keeping everything inside `.venv` gives Codex a stable interpreter path so it stops asking for approvals every time it opens a terminal, and it isolates dependencies from your global install to avoid version drift between human and agent sessions.
+
+  ```powershell
+  py -3.13 -m venv .venv
+  .\.venv\Scripts\Activate.ps1
+  python -m pip install -U pip
+  ```
+
+  After those steps, the checked-in `.vscode/settings.json` automatically pins `${workspaceFolder}\.venv\Scripts\python.exe` for both you and the Codex extension.
+
+* **Alternative – reuse an existing interpreter**: update the `python.defaultInterpreterPath` setting (or set the `RYAN_TOOLS_PYTHON` environment variable) to the interpreter you prefer. The repo task below falls back to that variable or to `python` on `PATH` if `.venv` is missing. Expect VS Code to prompt for interpreter approval more often in this mode because the path can change between sessions.
+
+To save the back-and-forth, run `python repo-scripts/ensure_venv.py` (or the **python:ensure-venv** task) before you start a Codex session. The script will create `.venv` if it is missing, upgrade `pip`, and install `requirements.txt`. It also stores a hash so `python repo-scripts/ensure_venv.py --check-only` can tell you whether the environment is still in sync when you come back later.
+
+### 2. Keep the shell stable
+
+Leave the integrated terminal on the default PowerShell profile. Changing shells mid-session forces the Codex agent to request approvals again.
+
+### 3. Provide a safe entry point for snippets
+
+Use the pre-defined **python:stdin** task (Tasks → Run Task → `python:stdin`) and pipe code into it. The task automatically selects the interpreter from step 1 and executes the code through `repo-scripts/run_snippet.py`, so the agent does not have to craft fragile `python -c` strings. If you want the task to launch a different snippet runner, set `RYAN_TOOLS_SNIPPET` to the alternative script path.
+
+Codex can also call the **python:ensure-venv** task whenever it needs to guarantee the repo-managed environment exists. That command resolves the same interpreter heuristics as `python:stdin`, so it works whether you stick with `.venv` or point `RYAN_TOOLS_PYTHON` at a different install.
+
+For anything non-trivial, drop the code into a reusable script—`python repo-scripts/<name>.py` or another module in the repo—so the agent can rerun it easily.
+

--- a/repo-scripts/ensure_venv.py
+++ b/repo-scripts/ensure_venv.py
@@ -1,0 +1,99 @@
+"""Create or refresh the repo's managed virtual environment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VENV_DIR = ROOT / ".venv"
+REQUIREMENTS = ROOT / "requirements.txt"
+HASH_FILE = VENV_DIR / ".requirements.sha256"
+
+
+def _venv_python() -> Path:
+    if os.name == "nt":
+        return VENV_DIR / "Scripts" / "python.exe"
+    return VENV_DIR / "bin" / "python"
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.check_call(cmd)
+
+
+def _requirements_hash() -> str:
+    sha = hashlib.sha256()
+    if REQUIREMENTS.exists():
+        sha.update(REQUIREMENTS.read_bytes())
+    return sha.hexdigest()
+
+
+def ensure_venv(force_recreate: bool) -> bool:
+    recreated = False
+    if force_recreate and VENV_DIR.exists():
+        shutil.rmtree(VENV_DIR)
+        recreated = True
+
+    if not VENV_DIR.exists():
+        _run([sys.executable, "-m", "venv", str(VENV_DIR)])
+        recreated = True
+
+    desired_hash = _requirements_hash()
+    recorded_hash = HASH_FILE.read_text().strip() if HASH_FILE.exists() else None
+    needs_sync = recreated or recorded_hash != desired_hash
+
+    if needs_sync and REQUIREMENTS.exists():
+        python = str(_venv_python())
+        _run([python, "-m", "pip", "install", "-U", "pip"])
+        _run([python, "-m", "pip", "install", "-r", str(REQUIREMENTS)])
+        HASH_FILE.write_text(desired_hash)
+
+    return VENV_DIR.exists() and not needs_sync
+
+
+def check_status() -> bool:
+    if not VENV_DIR.exists():
+        return False
+    desired_hash = _requirements_hash()
+    if not HASH_FILE.exists():
+        return False
+    return HASH_FILE.read_text().strip() == desired_hash
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Report whether .venv matches requirements.txt without changing anything.",
+    )
+    parser.add_argument(
+        "--force-recreate",
+        action="store_true",
+        help="Delete and recreate .venv before installing dependencies.",
+    )
+    args = parser.parse_args()
+
+    if args.check_only:
+        up_to_date = check_status()
+        if up_to_date:
+            print(".venv is present and matches requirements.txt")
+            return 0
+        print(".venv is missing or out of date")
+        return 1
+
+    up_to_date = ensure_venv(force_recreate=args.force_recreate)
+    if up_to_date:
+        print(".venv already satisfied requirements.txt")
+    else:
+        print("Ensured .venv matches requirements.txt")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/repo-scripts/run_snippet.py
+++ b/repo-scripts/run_snippet.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    code = sys.stdin.read()
+    exec(compile(code, "<stdin>", "exec"), {})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable python:ensure-venv VS Code task so Codex can bootstrap the repo environment
- provide repo-scripts/ensure_venv.py to create or refresh .venv and record requirements hashes
- document how to run the helper and check for stale environments in the Codex setup guide

## Testing
- python -m compileall repo-scripts/ensure_venv.py

------
https://chatgpt.com/codex/tasks/task_e_68e3b261b0ac832e9e5654d5124d45c0