### PR TITLE
[library] Reuse TUFLOW parser for string checks

### DIFF
--- a/ryan-scripts/fix-chatgpt-type-hints.py
+++ b/ryan-scripts/fix-chatgpt-type-hints.py
@@ -21,7 +21,9 @@ def fix_type_hints(file_path: Path) -> None:
                     print(f"Bad import found: {file_path} (Line {line_number}): {line.strip()}")
 
             original_line: str = line
-            # Replace incorrect type hints using regex
+            # Replace incorrect type hints using regex. Each pattern looks for the capitalised typing alias
+            # (e.g. ``Dict[``) and swaps it for the modern ``dict[`` form.
+            # Example: ``Tuple[int, str]`` becomes ``tuple[int, str]``.
             line: str = re.sub(pattern=r"\bDict\[", repl="dict[", string=line)
             line = re.sub(pattern=r"\bList\[", repl="list[", string=line)
             line = re.sub(pattern=r"\bTuple\[", repl="tuple[", string=line)

--- a/ryan_library/classes/tuflow_string_classes.py
+++ b/ryan_library/classes/tuflow_string_classes.py
@@ -56,8 +56,11 @@ class TuflowStringParser:
     """A class to parse Tuflow-specific strings and file paths."""
 
     # Precompile regex patterns for efficiency
+    # ``TP_PATTERN`` finds patterns like ``TP01`` that are surrounded by ``_`` or ``+`` (or appear at the edges).
     TP_PATTERN: re.Pattern[str] = re.compile(pattern=r"(?:[_+]|^)TP(\d{2})(?:[_+]|$)", flags=re.IGNORECASE)
+    # ``DURATION_PATTERN`` captures 3-5 digits followed by ``m`` (e.g. ``00360m`` or ``360m``).
     DURATION_PATTERN: re.Pattern[str] = re.compile(pattern=r"(?:[_+]|^)(\d{3,5})[mM](?:[_+]|$)", flags=re.IGNORECASE)
+    # ``AEP_PATTERN`` matches values like ``01.00p`` or ``5p`` and reads the numeric portion before ``p``.
     AEP_PATTERN: re.Pattern[str] = re.compile(
         pattern=r"(?:^|[_+])(\d+(?:\.\d{1,2})?)(?:p)(?=$|[_+])", flags=re.IGNORECASE
     )

--- a/ryan_library/functions/RORB/read_rorb_files.py
+++ b/ryan_library/functions/RORB/read_rorb_files.py
@@ -42,7 +42,12 @@ def _parse_run_line(line: str, batchout_file: Path) -> list[float | int | str] |
                 processed_line.append(el)
             else:
                 # everything else should be numeric; strip any trailing letters
-                m: re.Match[str] | None = re.match(pattern=r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][-+]?\d+)?", string=el)
+                # The pattern matches an optional sign, decimal number, and optional scientific exponent.
+                # Example matches include ``-12.5`` and ``3.1E-03``.
+                m: re.Match[str] | None = re.match(
+                    pattern=r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][-+]?\d+)?",
+                    string=el,
+                )
                 if m:
                     processed_line.append(float(m.group()))
                 else:

--- a/ryan_library/functions/data_processing.py
+++ b/ryan_library/functions/data_processing.py
@@ -3,6 +3,7 @@ import re  # Unlicensed regex
 from loguru import logger
 from typing import Any
 from _collections_abc import Callable
+from ryan_library.classes.tuflow_string_classes import TuflowStringParser
 
 
 def safe_apply(func: Callable[[Any], Any], value: Any) -> Any | None:
@@ -58,14 +59,11 @@ def check_string_TP(string: str) -> str:
     Raises:
         ValueError: If the TP pattern is not found in the string.
     """
-    # Regex pattern to find 'TP' followed by exactly two digits, with context checks
-    pattern = r"(?:[_+]|^)TP(\d{2})(?:[_+]|$)"
-    match: re.Match[str] | None = re.search(
-        pattern=pattern, string=string, flags=re.IGNORECASE
-    )
+    # Delegate to the shared parser pattern so logic lives in one place.
+    match: re.Match[str] | None = TuflowStringParser.TP_PATTERN.search(string)
 
     if match:
-        return match.group(1)  # Return the two digits following 'TP'
+        return match.group(1)
     else:
         raise ValueError(f"TP pattern not found in the string: {string}")
 
@@ -87,12 +85,10 @@ def check_string_duration(string: str) -> str:
     Raises:
         ValueError: If no duration pattern is found in the string.
     """
-    pattern = r"(?:[_+]|^)(\d{3,5}[mM])(?:[_+]|$)"
-    match: re.Match[str] | None = re.search(
-        pattern=pattern, string=string, flags=re.IGNORECASE
-    )
+    # Delegate to the shared parser pattern so logic lives in one place.
+    match: re.Match[str] | None = TuflowStringParser.DURATION_PATTERN.search(string)
     if match:
-        return match.group(0).replace("_", "").replace("m", "")
+        return match.group(1)
     else:
         raise ValueError(f"Duration pattern not found in the string: {string}")
 
@@ -114,11 +110,9 @@ def check_string_aep(string: str) -> str:
     Raises:
         ValueError: If no AEP pattern is found in the string.
     """
-    pattern = r"(?:[_+]|^)(\d{2}\.\d{1,2}p)(?:[_+]|$)"
-    match: re.Match[str] | None = re.search(
-        pattern=pattern, string=string, flags=re.IGNORECASE
-    )
+    # Delegate to the shared parser pattern so logic lives in one place.
+    match: re.Match[str] | None = TuflowStringParser.AEP_PATTERN.search(string)
     if match:
-        return match.group(0).replace("_", "").replace("p", "")
+        return match.group(1)
     else:
         raise ValueError(f"AEP pattern not found in the string: {string}")


### PR DESCRIPTION
## Summary
- import the shared `TuflowStringParser` in the legacy data processing helpers
- reuse the central TP, duration, and AEP regex patterns to keep behaviour consistent while avoiding duplicated logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3bc3a1d10832ea2c43c990fc7e70f