### PR TITLE
[ci] Add Codex auto review workflow

### DIFF
--- a/.github/workflows/codex-auto-review.yml
+++ b/.github/workflows/codex-auto-review.yml
@@ -1,0 +1,40 @@
+name: codex-auto-review
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  nudge-codex:
+    # Auto-trigger if you add label "codex" OR if the head branch starts with "codex/"
+    if: contains(github.event.pull_request.labels.*.name, 'codex') || startsWith(github.head_ref, 'codex/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Avoid duplicate nudges
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            // list last 50 comments and see if we've already asked for a review
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 50 });
+            const alreadyAsked = comments.some(c =>
+              c.body && c.body.trim().toLowerCase().includes('@codex review')
+            );
+            core.setOutput('already', alreadyAsked ? 'true' : 'false');
+
+      - name: Ask Codex to review
+        if: steps.check.outputs.already != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number,
+              body: "@codex review"
+            });


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that asks Codex to review PRs gated by the codex label or codex/ branches
- prevent duplicate comments by checking recent discussion before nudging Codex

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3c339082c832eb41fd37583d0c564