### PR TITLE
[library] Clean up Callable import in data processing

### DIFF
--- a/ryan_library/classes/suffixes_and_dtypes.py
+++ b/ryan_library/classes/suffixes_and_dtypes.py
@@ -24,7 +24,7 @@ class ConfigLoader:
             dict[str, Any]: The loaded JSON data."""
         try:
             with self.config_path.open("r", encoding="utf-8") as file:
-                config: dict = json.load(file)
+                config: dict[str, Any] = json.load(file)
                 logger.debug(f"Loaded configuration from {self.config_path}: {config}")
                 return config
         except FileNotFoundError:

--- a/ryan_library/functions/data_processing.py
+++ b/ryan_library/functions/data_processing.py
@@ -2,7 +2,7 @@
 import re  # Unlicensed regex
 from loguru import logger
 from typing import Any
-from _collections_abc import Callable
+from collections.abc import Callable
 from ryan_library.classes.tuflow_string_classes import TuflowStringParser
 
 


### PR DESCRIPTION
## Summary
- replace the `_collections_abc` Callable import with `collections.abc` in the data processing helper
- tighten the JSON config typing so mypy is satisfied when the module is imported

## Testing
- mypy ryan_library/functions/data_processing.py

------
https://chatgpt.com/codex/tasks/task_e_68e4dacd69ec832e8d0f795c640ebccf