### PR TITLE
[gdal] Tighten GDAL environment type annotations

### DIFF
--- a/ryan_library/functions/gdal/gdal_environment.py
+++ b/ryan_library/functions/gdal/gdal_environment.py
@@ -66,7 +66,7 @@ def find_python_installation(qgis_path: Path) -> Path:
     return python_dir
 
 
-def setup_environment(qgis_path: Path = None):
+def setup_environment(qgis_path: Path | None = None) -> None:
     """
     Set up the environment variables needed for GDAL processing based on the QGIS/OSGeo4W installation path.
 
@@ -123,7 +123,7 @@ def setup_environment(qgis_path: Path = None):
     logger.debug("GDAL tool paths set in environment variables.")
 
 
-def check_executable(path: str, name: str):
+def check_executable(path: str, name: str) -> None:
     """
     Check if the specified executable or script exists.
 
@@ -141,7 +141,7 @@ def check_executable(path: str, name: str):
         raise FileNotFoundError(f"{name} not found at {path}.")
 
 
-def check_required_components():
+def check_required_components() -> None:
     """
     Check that all required GDAL components are available.
 

--- a/ryan_library/functions/gdal/gdal_runners.py
+++ b/ryan_library/functions/gdal/gdal_runners.py
@@ -6,7 +6,9 @@ from loguru import logger
 import os
 
 
-def run_gdal_calc(input_file: Path, output_file: str, cutoff: float):
+def run_gdal_calc(
+    input_file: Path | str, output_file: Path | str, cutoff: float
+) -> None:
     """
     Run gdal_calc.py with the specified parameters.
 
@@ -30,7 +32,7 @@ def run_gdal_calc(input_file: Path, output_file: str, cutoff: float):
         "-A",
         str(input_file),
         "--outfile",
-        output_file,
+        str(output_file),
     ] + create_opts.split()
 
     logger.debug(f"Running GDAL Calc Command: {' '.join(gdal_calc_cmd)}")
@@ -43,7 +45,7 @@ def run_gdal_calc(input_file: Path, output_file: str, cutoff: float):
         raise
 
 
-def run_gdal_polygonize(input_file: str, output_shp: str):
+def run_gdal_polygonize(input_file: Path | str, output_shp: Path | str) -> None:
     """
     Run gdal_polygonize.py to convert the raster to a polygon.
 
@@ -56,7 +58,12 @@ def run_gdal_polygonize(input_file: str, output_shp: str):
         logger.error("GDAL_POLYGONIZE_PATH is not set in environment variables.")
         raise EnvironmentError("GDAL_POLYGONIZE_PATH is not set.")
 
-    gdal_polygonize_cmd = ["python", gdal_polygonize_path, input_file, output_shp]
+    gdal_polygonize_cmd = [
+        "python",
+        gdal_polygonize_path,
+        str(input_file),
+        str(output_shp),
+    ]
 
     logger.debug(f"Running GDAL Polygonize Command: {' '.join(gdal_polygonize_cmd)}")
 


### PR DESCRIPTION
## Summary
- add explicit return types for GDAL environment helpers to satisfy stricter typing
- broaden runner parameter annotations to accept both Path and str inputs while returning None

## Testing
- mypy ryan_library/functions/gdal

------
https://chatgpt.com/codex/tasks/task_e_68e4db05b0d4832e9d9c96c4b07dd0eb